### PR TITLE
Add fields which are in existing JSON, but not the API proto

### DIFF
--- a/proto/google/events/cloud/storage/v1/events.proto
+++ b/proto/google/events/cloud/storage/v1/events.proto
@@ -174,4 +174,10 @@ message StorageObjectData {
   // Metadata of customer-supplied encryption key, if the object is encrypted by
   // such a key.
   CustomerEncryption customer_encryption = 28;
+
+  // The link to this object.
+  string media_link = 100;
+
+  // Media download link.
+  string self_link = 101;
 }


### PR DESCRIPTION
The field numbers are intended to be high enough to avoid conflicts
with new API fields.

Note that "kind" is not included here, as it's not expected to be
useful.

Part of addressing #6 