### PR TITLE
Remove execution time from scheduler schema

### DIFF
--- a/proto/google/events/cloud/scheduler/v1/events.proto
+++ b/proto/google/events/cloud/scheduler/v1/events.proto
@@ -34,7 +34,4 @@ message JobExecutedEvent {
 message SchedulerData {
   // The custom data the user specified when creating the scheduler source.
   bytes custom_data = 1;
-
-  // The time at which the job was executed, populated by the server.
-  google.protobuf.Timestamp execution_time = 2;
 }


### PR DESCRIPTION
Reason: we will put time in standard CE time attribute.