### PR TITLE
Change the Storage event_based_hold field to bool

### DIFF
--- a/proto/google/events/cloud/storage/v1/data.proto
+++ b/proto/google/events/cloud/storage/v1/data.proto
@@ -17,7 +17,6 @@ syntax = "proto3";
 package google.events.cloud.storage.v1;
 
 import "google/protobuf/timestamp.proto";
-import "google/protobuf/wrappers.proto";
 
 option csharp_namespace = "Google.Events.Protobuf.Cloud.Storage.V1";
 
@@ -118,7 +117,7 @@ message StorageObjectData {
   map<string, string> metadata = 21;
 
   // Whether an object is under event-based hold.
-  google.protobuf.BoolValue event_based_hold = 29;
+  bool event_based_hold = 29;
 
   // The name of the object.
   string name = 23;


### PR DESCRIPTION
It's a BoolWrapper in the API to allow the distinction between
"false", "true" and "unset" for the purpose of inheriting values
from the bucket on object creation. This is unnecessary for event
consumption.

Fixes #6.