### PR TITLE
Rename scheduler data message

### DIFF
--- a/proto/google/events/cloud/scheduler/v1/data.proto
+++ b/proto/google/events/cloud/scheduler/v1/data.proto
@@ -18,8 +18,8 @@ package google.events.cloud.scheduler.v1;
 
 option csharp_namespace = "Google.Events.Protobuf.Cloud.Scheduler.V1";
 
-// Scheduler event data.
-message SchedulerData {
+// Scheduler job executed event data.
+message JobExecutedData {
   // The custom data the user specified when creating the scheduler source.
   bytes custom_data = 1;
 }

--- a/proto/google/events/cloud/scheduler/v1/events.proto
+++ b/proto/google/events/cloud/scheduler/v1/events.proto
@@ -27,5 +27,5 @@ message JobExecutedEvent {
       "google.cloud.scheduler.job.v1.executed";
 
   // The data associated with the event.
-  SchedulerData data = 1;
+  JobExecutedData data = 1;
 }


### PR DESCRIPTION
Renamed to `JobExecutedData`. This would be consistent with other data messages naming.