### PR TITLE
Use a smaller extension field number for the cloud_event_type

### DIFF
--- a/proto/google/events/cloudevent.proto
+++ b/proto/google/events/cloudevent.proto
@@ -23,5 +23,5 @@ option csharp_namespace = "Google.Events.Protobuf";
 extend google.protobuf.MessageOptions {
   // The CloudEvent type (e.g. "google.cloud.storage.object.v1.finalized")
   // that relates to this message.
-  string cloud_event_type = 311716486;
+  string cloud_event_type = 11716486;
 }


### PR DESCRIPTION
While the field number here *should* be valid, it at least causes
problems in C#. I'll investigate whether this is a Google.Protobuf bug
separately, but it does no harm to use a smaller number here.