### PR TITLE
Update Firestore event data proto to match internal field ordering

### DIFF
--- a/proto/google/events/cloud/firestore/v1/data.proto
+++ b/proto/google/events/cloud/firestore/v1/data.proto
@@ -24,17 +24,17 @@ option csharp_namespace = "Google.Events.Protobuf.Cloud.Firestore.V1";
 
 // The data within all Firestore document events.
 message DocumentEventData {
+  // A Document object containing a post-operation document snapshot.
+  // This is not populated for delete events. (TODO: check this!)
+  Document value = 1;
+
   // A Document object containing a pre-operation document snapshot.
   // This is only populated for update and delete events.
-  Document old_value = 1;
+  Document old_value = 2;
 
   // A DocumentMask object that lists changed fields.
   // This is only populated for update events.
-  DocumentMask update_mask = 2;
-
-  // A Document object containing a post-operation document snapshot.
-  // This is not populated for delete events. (TODO: check this!)
-  Document value = 3;
+  DocumentMask update_mask = 3;
 
   // The matches from wildcards specified in the event subscription, to the
   // values of those wildcards in the document name. For example,


### PR DESCRIPTION
This doesn't affect the JSON representation at all, but we might as
well match internal proto field numbers where possible - it may have
advantages in the future if we want to deliver proto binary
representations of events.