### PR TITLE
README Event Directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ may change. Even the core `cloud_event_type` annotation may change.
 
 The following list is generated from the contents in the `proto/` directory.
 
-- [Google.Events.Protobuf.Firebase.V1](./proto/google/events/firebase/v1/data.proto)
-- [Google.Events.Protobuf.Cloud.Firestore.V1](./proto/google/events/cloud/firestore/v1/data.proto)
-- [Google.Events.Protobuf.Cloud.Scheduler.V1](./proto/google/events/cloud/scheduler/v1/data.proto)
-- [Google.Events.Protobuf.Cloud.Storage.V1](./proto/google/events/cloud/storage/v1/data.proto)
-- [Google.Events.Protobuf.Cloud.Audit.V1](./proto/google/events/cloud/audit/v1/data.proto)
-- [Google.Events.Protobuf.Cloud.PubSub.V1](./proto/google/events/cloud/pubsub/v1/data.proto)
+- [google.events.firebase.v1](./proto/google/events/firebase/v1/data.proto)
+- [google.events.cloud.firestore.v1](./proto/google/events/cloud/firestore/v1/data.proto)
+- [google.events.cloud.scheduler.v1](./proto/google/events/cloud/scheduler/v1/data.proto)
+- [google.events.cloud.storage.v1](./proto/google/events/cloud/storage/v1/data.proto)
+- [google.events.cloud.audit.v1](./proto/google/events/cloud/audit/v1/data.proto)
+- [google.events.cloud.pubsub.v1](./proto/google/events/cloud/pubsub/v1/data.proto)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Google Events
+# Google CloudEvents
 
 [![Build Status](https://travis-ci.org/googleapis/google-cloudevents.svg?branch=master)](https://travis-ci.org/googleapis/google-cloudevents)
 
@@ -21,3 +21,10 @@ may change. Even the core `cloud_event_type` annotation may change.
 # CloudEvent Types
 
 The following list is generated from the contents in the `proto/` directory.
+
+- [Google.Events.Protobuf.Firebase.V1](./proto/google/events/firebase/v1/data.proto)
+- [Google.Events.Protobuf.Cloud.Firestore.V1](./proto/google/events/cloud/firestore/v1/data.proto)
+- [Google.Events.Protobuf.Cloud.Scheduler.V1](./proto/google/events/cloud/scheduler/v1/data.proto)
+- [Google.Events.Protobuf.Cloud.Storage.V1](./proto/google/events/cloud/storage/v1/data.proto)
+- [Google.Events.Protobuf.Cloud.Audit.V1](./proto/google/events/cloud/audit/v1/data.proto)
+- [Google.Events.Protobuf.Cloud.PubSub.V1](./proto/google/events/cloud/pubsub/v1/data.proto)

--- a/README.md
+++ b/README.md
@@ -17,3 +17,7 @@ The entire content of this repository should be regarded as highly
 unstable until this warning is removed. The schema may change, the
 CloudEvent "type" attribute values may change, the protobuf message
 may change. Even the core `cloud_event_type` annotation may change.
+
+# CloudEvent Types
+
+The following list is generated from the contents in the `proto/` directory.

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,9 @@
+# Tools
+
+## gen_readme.sh
+
+Generates a list of events for use in the README.
+
+```sh
+./gen_readme.sh
+```

--- a/tools/gen_readme.sh
+++ b/tools/gen_readme.sh
@@ -2,13 +2,15 @@
 cd ..
 for f in $(find . -name 'data.proto' -or -name 'events.proto'); do
   # echo $f;
-  c=$(grep 'csharp_namespace' $f)
-  c_no_quotes=`echo "$c" | cut -d'"' -f 2`
+  c=$(grep 'package' $f)
+  # c_no_quotes=`echo "$c" | cut -d'"' -f 2`
 
   # Only print .data files
   STR=$f
   SUB="data.proto"
   if [[ "$STR" == *"$SUB"* ]]; then
-    echo "- [$c_no_quotes]($f)"
+    # Trim off text "package " and ";""
+    package=${c:8:${#c}-9}
+    echo "- [$package]($f)"
   fi
 done

--- a/tools/gen_readme.sh
+++ b/tools/gen_readme.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+cd ..
+for f in $(find . -name 'data.proto' -or -name 'events.proto'); do
+  # echo $f;
+  c=$(grep 'csharp_namespace' $f)
+  c_no_quotes=`echo "$c" | cut -d'"' -f 2`
+
+  # Only print .data files
+  STR=$f
+  SUB="data.proto"
+  if [[ "$STR" == *"$SUB"* ]]; then
+    echo "- [$c_no_quotes]($f)"
+  fi
+done

--- a/tools/gen_readme.sh
+++ b/tools/gen_readme.sh
@@ -1,16 +1,14 @@
 #!/bin/bash
 cd ..
 for f in $(find . -name 'data.proto' -or -name 'events.proto'); do
-  # echo $f;
-  c=$(grep 'package' $f)
-  # c_no_quotes=`echo "$c" | cut -d'"' -f 2`
+  package_string=$(grep 'package' $f)
 
   # Only print .data files
   STR=$f
   SUB="data.proto"
   if [[ "$STR" == *"$SUB"* ]]; then
     # Trim off text "package " and ";""
-    package=${c:8:${#c}-9}
+    package=${package_string:8:${#package_string}-9}
     echo "- [$package]($f)"
   fi
 done


### PR DESCRIPTION
Fixes #24.

- Matches the README H1 to the repo title (CloudEvents)
- Adds a generated list of CloudEvent Type links to the README for easy lookup. Uses the `csharp_namespace` for now.
- Adds the little bash script that create this generated list.


Look roughly like this (relative links don't work in PR comments):

- [google.events.firebase.v1](./proto/google/events/firebase/v1/data.proto)
- [google.events.cloud.firestore.v1](./proto/google/events/cloud/firestore/v1/data.proto)
- [google.events.cloud.scheduler.v1](./proto/google/events/cloud/scheduler/v1/data.proto)
- [google.events.cloud.storage.v1](./proto/google/events/cloud/storage/v1/data.proto)
- [google.events.cloud.audit.v1](./proto/google/events/cloud/audit/v1/data.proto)
- [google.events.cloud.pubsub.v1](./proto/google/events/cloud/pubsub/v1/data.proto)