### PR TITLE
Remove "wildcards" from Firestore document event data

### DIFF
--- a/proto/google/events/cloud/firestore/v1/data.proto
+++ b/proto/google/events/cloud/firestore/v1/data.proto
@@ -35,15 +35,6 @@ message DocumentEventData {
   // A DocumentMask object that lists changed fields.
   // This is only populated for update events.
   DocumentMask update_mask = 3;
-
-  // The matches from wildcards specified in the event subscription, to the
-  // values of those wildcards in the document name. For example,
-  // a subscription to
-  // `/projects/my_project/databases/(default)/documents/users/{username}`
-  // matching a document with name
-  // `/projects/my_project/databases/(default)/documents/users/marie`
-  // would result in a mapping of `'username': 'marie'`.
-  map<string, string> wildcards = 4;
 }
 
 // A set of field paths on a document.


### PR DESCRIPTION
Internal discussions suggest this shouldn't be part of the event
data. (It isn't part of the payload in GCF events; it's provided
as a separate field in the root of the event body.) Client libraries
can provide manually-written code to parse document names instead.

Philosophically, this isn't part of the underlying event - it
depends on the event subscription (which contains the resource
template being used).

Cc:

- @yolocs (Events)
- @mbleigh (Firebase)
- @hrasadi (Events)
- @fredzqm (Firebase)