### PR TITLE
Prototype of changing the CAL handling

### DIFF
--- a/proto/google/events/cloud/audit/v1/data.proto
+++ b/proto/google/events/cloud/audit/v1/data.proto
@@ -17,16 +17,31 @@ syntax = "proto3";
 package google.events.cloud.audit.v1;
 
 import "google/protobuf/struct.proto";
+import "google/protobuf/timestamp.proto";
 import "google/rpc/context/attribute_context.proto";
 import "google/rpc/status.proto";
 
 option csharp_namespace = "Google.Events.Protobuf.Cloud.Audit.V1";
 
+message LogEntryData {
+  AuditLog proto_payload = 2;
+  string insert_id = 4;
+  google.protobuf.Timestamp timestamp = 9;
+  string log_name = 12;
+  // TODO: severity, resource (both need external messages)
+}
+
 // Common audit log format for Google Cloud Platform API operations.
 // Copied from
 // https://github.com/googleapis/googleapis/blob/master/google/cloud/audit/audit_log.proto,
 // but changing service_data from Any to Struct.
-message AuditLogData {
+message AuditLog {
+
+  // Synthetic field to match the "@type" in the JSON representation
+  // of the AuditLog, which comes from proto_payload actually being an Any
+  // in the LogEntry message.
+  string original_protobuf_type = 1000 [json_name = "@type"];
+
   // The name of the API service performing the operation. For example,
   // `"datastore.googleapis.com"`.
   string service_name = 7;

--- a/proto/google/events/cloud/audit/v1/events.proto
+++ b/proto/google/events/cloud/audit/v1/events.proto
@@ -26,5 +26,5 @@ message AuditLogWrittenEvent {
   option (google.events.cloud_event_type) = "google.cloud.audit.log.v1.written";
 
   // The data associated with the event.
-  AuditLogData data = 1;
+  LogEntryData data = 1;
 }


### PR DESCRIPTION
Two significant changes here:

- There's an extra level of wrapping, as the CloudEvent data is a `LogEntry`, not an `AuditLog`
- Introduced an extra somewhat-synthetic field into `AuditLog` with a JSON key of "@type"

This is incomplete - it's just a prototype for test purposes (as there's more data in LogEntry) but I've tried generating the code with C#, and yes, we can retrieve the value from the `@type` field in the JSON.
If `AuditLog` is now packed into an `Any` and converted to JSON (with an appropriate type registry), we now get two `@type` fields in the JSON output, which is basically broken... but we *could* decide that's an acceptable edge case.