### PR TITLE
Wrap Cloud Audit Logs in a LogEntry proto

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,22 @@ This repository contains definitions for the following CloudEvents:
 
 |Package|Event types|Data messages|
 |-|-|-|
+|[google.events.cloud.audit.v1](proto/google/events/cloud/audit/v1)|google.cloud.audit.log.v1.written|LogEntryData|
+|[google.events.cloud.build.v1](proto/google/events/cloud/build/v1)|google.cloud.cloudbuild.build.v1.statusChanged|BuildEventData|
+|[google.events.cloud.firestore.v1](proto/google/events/cloud/firestore/v1)|google.cloud.firestore.document.v1.created<br/>google.cloud.firestore.document.v1.deleted<br/>google.cloud.firestore.document.v1.updated<br/>google.cloud.firestore.document.v1.written|DocumentEventData|
+|[google.events.cloud.pubsub.v1](proto/google/events/cloud/pubsub/v1)|google.cloud.pubsub.topic.v1.messagePublished|MessagePublishedData|
+|[google.events.cloud.scheduler.v1](proto/google/events/cloud/scheduler/v1)|google.cloud.scheduler.job.v1.executed|SchedulerJobData|
+|[google.events.cloud.storage.v1](proto/google/events/cloud/storage/v1)|google.cloud.storage.object.v1.archived<br/>google.cloud.storage.object.v1.deleted<br/>google.cloud.storage.object.v1.finalized<br/>google.cloud.storage.object.v1.metadataUpdated|StorageObjectData|
+|[google.events.firebase.analytics.v1](proto/google/events/firebase/analytics/v1)|google.firebase.analytics.log.v1.written|AnalyticsLogData|
+|[google.events.firebase.auth.v1](proto/google/events/firebase/auth/v1)|google.firebase.auth.user.v1.deleted<br/>google.firebase.auth.user.v1.updated|AuthEventData|
+|[google.events.firebase.database.v1](proto/google/events/firebase/database/v1)|google.firebase.database.ref.v1.created<br/>google.firebase.database.ref.v1.deleted<br/>google.firebase.database.ref.v1.updated<br/>google.firebase.database.ref.v1.written|ReferenceEventData|
+|[google.events.firebase.remoteconfig.v1](proto/google/events/firebase/remoteconfig/v1)|google.firebase.remoteconfig.remoteConfig.v1.updated|RemoteConfigEventData|
+<<<<<<< HEAD
 |[google.events.cloud.audit.v1](proto/google/events/cloud/audit/v1)|google.cloud.audit.log.v1.written|AuditLogData|
 |[google.events.cloud.build.v1](proto/google/events/cloud/build/v1)|google.cloud.cloudbuild.build.v1.statusChanged|BuildEventData|
+=======
+|[google.events.cloud.audit.v1](proto/google/events/cloud/audit/v1)|google.cloud.audit.log.v1.written|LogEntryData|
+>>>>>>> Wrap Cloud Audit Log event data in a log entry, to match reality on Cloud Run
 |[google.events.cloud.firestore.v1](proto/google/events/cloud/firestore/v1)|google.cloud.firestore.document.v1.created<br/>google.cloud.firestore.document.v1.deleted<br/>google.cloud.firestore.document.v1.updated<br/>google.cloud.firestore.document.v1.written|DocumentEventData|
 |[google.events.cloud.pubsub.v1](proto/google/events/cloud/pubsub/v1)|google.cloud.pubsub.topic.v1.messagePublished|MessagePublishedData|
 |[google.events.cloud.scheduler.v1](proto/google/events/cloud/scheduler/v1)|google.cloud.scheduler.job.v1.executed|SchedulerJobData|

--- a/proto/google/events/cloud/audit/v1/data.proto
+++ b/proto/google/events/cloud/audit/v1/data.proto
@@ -16,17 +16,124 @@ syntax = "proto3";
 
 package google.events.cloud.audit.v1;
 
+import "google/api/monitored_resource.proto";
 import "google/protobuf/struct.proto";
+import "google/protobuf/timestamp.proto";
 import "google/rpc/context/attribute_context.proto";
 import "google/rpc/status.proto";
 
 option csharp_namespace = "Google.Events.Protobuf.Cloud.Audit.V1";
 
+// Generic log entry, used as a wrapper for Cloud Audit Logs in events.
+// This is copied from
+// https://github.com/googleapis/googleapis/blob/master/google/logging/v2/log_entry.proto
+// and adapted appropriately.
+message LogEntryData {
+  // The resource name of the log to which this log entry belongs.
+  string log_name = 12;
+
+  // The monitored resource that produced this log entry.
+  //
+  // Example: a log entry that reports a database error would be associated with
+  // the monitored resource designating the particular database that reported
+  // the error.
+  google.api.MonitoredResource resource = 8;
+
+  // The log entry payload, which is always an AuditLog for Cloud Audit Log events.
+  AuditLog proto_payload = 2;
+
+  // A unique identifier for the log entry. 
+  string insert_id = 4;
+
+  // A set of user-defined (key, value) data that provides additional
+  // information about the log entry.
+  map<string, string> labels = 11;
+
+  // Information about an operation associated with the log entry, if applicable.
+  LogEntryOperation operation = 15;
+
+  // The time the event described by the log entry occurred.
+  google.protobuf.Timestamp timestamp = 9;
+
+  // The time the log entry was received by Logging.
+  google.protobuf.Timestamp receive_timestamp = 24;
+
+  // The severity of the log entry.
+  LogSeverity severity = 10;
+
+  // Resource name of the trace associated with the log entry, if any. If it
+  // contains a relative resource name, the name is assumed to be relative to
+  // `//tracing.googleapis.com`. Example:
+  // `projects/my-projectid/traces/06796866738c859f2f19b7cfb3214824`
+  string trace = 22;
+
+  // The span ID within the trace associated with the log entry, if any.
+  //
+  // For Trace spans, this is the same format that the Trace API v2 uses: a
+  // 16-character hexadecimal encoding of an 8-byte array, such as
+  // `000000000000004a`.
+  string span_id = 27;
+}
+
+// Additional information about a potentially long-running operation with which
+// a log entry is associated.
+message LogEntryOperation {
+  // An arbitrary operation identifier. Log entries with the same
+  // identifier are assumed to be part of the same operation.
+  string id = 1;
+
+  // An arbitrary producer identifier. The combination of `id` and
+  // `producer` must be globally unique. Examples for `producer`:
+  // `"MyDivision.MyBigCompany.com"`, `"github.com/MyProject/MyApplication"`.
+  string producer = 2;
+
+  // True if this is the first log entry in the operation.
+  bool first = 3;
+
+  // True if this is the last log entry in the operation.
+  bool last = 4;
+}
+
+// The severity of the event described in a log entry, expressed as one of the
+// standard severity levels listed below.  For your reference, the levels are
+// assigned the listed numeric values. The effect of using numeric values other
+// than those listed is undefined.
+// Copied from https://github.com/googleapis/googleapis/blob/master/google/logging/type/log_severity.proto
+enum LogSeverity {
+  // (0) The log entry has no assigned severity level.
+  DEFAULT = 0;
+
+  // (100) Debug or trace information.
+  DEBUG = 100;
+
+  // (200) Routine information, such as ongoing status or performance.
+  INFO = 200;
+
+  // (300) Normal but significant events, such as start up, shut down, or
+  // a configuration change.
+  NOTICE = 300;
+
+  // (400) Warning events might cause problems.
+  WARNING = 400;
+
+  // (500) Error events are likely to cause problems.
+  ERROR = 500;
+
+  // (600) Critical events cause more severe problems or outages.
+  CRITICAL = 600;
+
+  // (700) A person must take an action immediately.
+  ALERT = 700;
+
+  // (800) One or more systems are unusable.
+  EMERGENCY = 800;
+}
+
 // Common audit log format for Google Cloud Platform API operations.
 // Copied from
 // https://github.com/googleapis/googleapis/blob/master/google/cloud/audit/audit_log.proto,
 // but changing service_data from Any to Struct.
-message AuditLogData {
+message AuditLog {
   // The name of the API service performing the operation. For example,
   // `"datastore.googleapis.com"`.
   string service_name = 7;

--- a/proto/google/events/cloud/audit/v1/events.proto
+++ b/proto/google/events/cloud/audit/v1/events.proto
@@ -26,5 +26,5 @@ message AuditLogWrittenEvent {
   option (google.events.cloud_event_type) = "google.cloud.audit.log.v1.written";
 
   // The data associated with the event.
-  AuditLogData data = 1;
+  LogEntryData data = 1;
 }

--- a/testdata/google/events/cloud/audit/v1/LogEntryData-pubsubCreateTopic.json
+++ b/testdata/google/events/cloud/audit/v1/LogEntryData-pubsubCreateTopic.json
@@ -1,0 +1,93 @@
+{
+  "insertId": "9frck8cf9j",
+  "logName": "projects/test-project/logs/cloudaudit.googleapis.com%2Factivity",
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "authenticationInfo": {
+      "principalEmail": "robot@test-project.iam.gserviceaccount.com",
+      "principalSubject": "user:robot@test-project.iam.gserviceaccount.com",
+      "serviceAccountKeyName": "//iam.googleapis.com/projects/test-project/serviceAccounts/robot@test-project.iam.gserviceaccount.com/keys/90f662482321f1ca8e82ea675b1a1c30c1fe681f"
+    },
+    "authorizationInfo": [
+      {
+        "granted": true,
+        "permission": "pubsub.topics.create",
+        "resource": "projects/test-project",
+        "resourceAttributes": {}
+      }
+    ],
+    "methodName": "google.pubsub.v1.Publisher.CreateTopic",
+    "request": {
+      "@type": "type.googleapis.com/google.pubsub.v1.Topic",
+      "name": "projects/test-project/topics/test-auditlogs-source"
+    },
+    "requestMetadata": {
+      "callerIp": "192.168.0.1",
+      "callerNetwork": "//compute.googleapis.com/projects/google.com:my-laptop/global/networks/__unknown__",
+      "callerSuppliedUserAgent": "google-cloud-sdk",
+      "destinationAttributes": {},
+      "requestAttributes": {
+        "auth": {},
+        "time": "2020-06-30T16:14:47.600710407Z"
+      }
+    },
+    "resourceLocation": {
+      "currentLocations": [
+        "asia-east1",
+        "asia-northeast1",
+        "asia-southeast1",
+        "australia-southeast1",
+        "europe-north1",
+        "europe-west1",
+        "europe-west2",
+        "europe-west3",
+        "europe-west4",
+        "us-central1",
+        "us-central2",
+        "us-east1",
+        "us-east4",
+        "us-west1",
+        "us-west2",
+        "us-west3",
+        "us-west4"
+      ]
+    },
+    "resourceName": "projects/test-project/topics/test-auditlogs-source",
+    "response": {
+      "@type": "type.googleapis.com/google.pubsub.v1.Topic",
+      "messageStoragePolicy": {
+        "allowedPersistenceRegions": [
+          "asia-east1",
+          "asia-northeast1",
+          "asia-southeast1",
+          "australia-southeast1",
+          "europe-north1",
+          "europe-west1",
+          "europe-west2",
+          "europe-west3",
+          "europe-west4",
+          "us-central1",
+          "us-central2",
+          "us-east1",
+          "us-east4",
+          "us-west1",
+          "us-west2",
+          "us-west3",
+          "us-west4"
+        ]
+      },
+      "name": "projects/test-project/topics/test-auditlogs-source"
+    },
+    "serviceName": "pubsub.googleapis.com"
+  },
+  "receiveTimestamp": "2020-06-30T16:14:48.401489148Z",
+  "resource": {
+    "labels": {
+      "project_id": "test-project",
+      "topic_id": "projects/test-project/topics/test-auditlogs-source"
+    },
+    "type": "pubsub_topic"
+  },
+  "severity": "NOTICE",
+  "timestamp": "2020-06-30T16:14:47.593398572Z"
+}

--- a/third_party/googleapis/README.md
+++ b/third_party/googleapis/README.md
@@ -9,8 +9,12 @@ These files, and *only* these files, can be imported from event
 types defined in the `proto` directory.
 
 Initially, this consists of just the `google.type` and `google.rpc`
-packages; other proto packages could potentially be added later, but
-these are likely to cover the majority of use cases.
+packages, along with `google.api.MonitoredResource`. Other proto
+packages could potentially be added later, but these are likely to
+cover the majority of use cases.
+
+This directory should be carefully and consciously curated too avoid
+events depending on too much other Google infrastructure.
 
 We could potentially use a submodule for this, but explicitly
 copying a subset of the protos allows for simpler governance over

--- a/third_party/googleapis/google/api/monitored_resource.proto
+++ b/third_party/googleapis/google/api/monitored_resource.proto
@@ -1,0 +1,34 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.api;
+
+// Note: this is a much-reduced version of the proto at
+// https://github.com/googleapis/googleapis/blob/master/google/api/monitored_resource.proto
+// to avoid other dependencies leaking into events.
+
+// An object representing a resource that can be used for monitoring, logging,
+// billing, or other purposes.
+message MonitoredResource {
+  // Required. The monitored resource type. For example, the type of a 
+  // Compute Engine VM instance is `gce_instance`.
+  string type = 1;
+
+  // Values for all of the labels listed in the associated monitored
+  // resource descriptor. For example, Compute Engine VM instances use the
+  // labels `"project_id"`, `"instance_id"`, and `"zone"`.
+  map<string, string> labels = 2;
+}


### PR DESCRIPTION
(Replaces the prototype in #47.)

This is ready for review, but we should dig more carefully to work out how to answer the questions in the second commit.

This PR does *not* include anything that will interpret the `@type` field that is emitted as a byproduct of the `Any` field.