### PR TITLE
Fix: Storage object improvements

### DIFF
--- a/proto/google/events/cloud/storage/v1/data.proto
+++ b/proto/google/events/cloud/storage/v1/data.proto
@@ -137,9 +137,12 @@ message StorageObjectData {
   // such a key.
   CustomerEncryption customer_encryption = 28;
 
-  // The link to this object.
+  // Media download link.
   string media_link = 100;
 
-  // Media download link.
+  // The link to this object.
   string self_link = 101;
+
+  // The kind of item this is. For objects, this is always "storage#object".
+  string kind = 102;
 }


### PR DESCRIPTION
- Media/self link comments were the wrong way round
- Add the "kind" field for completeness - it will always have the same value, but it *is* part of the REST resource model

I have *not* included custom_time (despite it being in the Discovery doc) as I believe aspects of this are still in flux.