### PR TITLE
fix: Move the CloudBuild events under google.events.cloud.cloudbuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This repository contains definitions for the following CloudEvents:
 |Package|Event types|Data messages|
 |-|-|-|
 |[google.events.cloud.audit.v1](proto/google/events/cloud/audit/v1)|google.cloud.audit.log.v1.written|LogEntryData|
-|[google.events.cloud.build.v1](proto/google/events/cloud/build/v1)|google.cloud.cloudbuild.build.v1.statusChanged|BuildEventData|
+|[google.events.cloud.cloudbuild.v1](proto/google/events/cloud/cloudbuild/v1)|google.cloud.cloudbuild.build.v1.statusChanged|BuildEventData|
 |[google.events.cloud.firestore.v1](proto/google/events/cloud/firestore/v1)|google.cloud.firestore.document.v1.created<br/>google.cloud.firestore.document.v1.deleted<br/>google.cloud.firestore.document.v1.updated<br/>google.cloud.firestore.document.v1.written|DocumentEventData|
 |[google.events.cloud.pubsub.v1](proto/google/events/cloud/pubsub/v1)|google.cloud.pubsub.topic.v1.messagePublished|MessagePublishedData|
 |[google.events.cloud.scheduler.v1](proto/google/events/cloud/scheduler/v1)|google.cloud.scheduler.job.v1.executed|SchedulerJobData|

--- a/proto/google/events/cloud/cloudbuild/v1/data.proto
+++ b/proto/google/events/cloud/cloudbuild/v1/data.proto
@@ -14,12 +14,13 @@
 
 syntax = "proto3";
 
-package google.events.cloud.build.v1;
+package google.events.cloud.cloudbuild.v1;
 
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 
-option csharp_namespace = "Google.Events.Protobuf.Cloud.Build.V1";
+option csharp_namespace = "Google.Events.Protobuf.Cloud.CloudBuild.V1";
+
 // Build event data
 // Common build format for Google Cloud Platform API operations.
 // Copied from

--- a/proto/google/events/cloud/cloudbuild/v1/events.proto
+++ b/proto/google/events/cloud/cloudbuild/v1/events.proto
@@ -14,11 +14,11 @@
 
 syntax = "proto3";
 
-package google.events.cloud.build.v1;
+package google.events.cloud.cloudbuild.v1;
 
-option csharp_namespace = "Google.Events.Protobuf.Cloud.Build.V1";
+option csharp_namespace = "Google.Events.Protobuf.Cloud.CloudBuild.V1";
 
-import "google/events/cloud/build/v1/data.proto";
+import "google/events/cloud/cloudbuild/v1/data.proto";
 import "google/events/cloudevent.proto";
 
 // The CloudEvent raised when your build's state changes.


### PR DESCRIPTION
This makes the proto structure match the event type.
(The duplication of "cloud" in the name has been discussed
separately.)

cc @yolocs. @capri-xiyue 