### PR TITLE
fix: fix pub/sub message json schema

### DIFF
--- a/proto/google/events/cloud/pubsub/v1/schema.json
+++ b/proto/google/events/cloud/pubsub/v1/schema.json
@@ -19,7 +19,7 @@
                         "attributes": {
                             "type": "object"
                         },
-                        "message_id": {
+                        "messageId": {
                             "type": "string"
                         }
                     }


### PR DESCRIPTION
Fixes the json schema for Pub/Sub, key `messageId`.

See: https://cloud.google.com/pubsub/docs/reference/rest/v1/PubsubMessage
Fixes: https://github.com/googleapis/google-cloudevents/issues/64