### PR TITLE
feat: update JSON Schema descriptions and references

### DIFF
--- a/proto/google/events/cloud/audit/v1/LogEntryData.json
+++ b/proto/google/events/cloud/audit/v1/LogEntryData.json
@@ -1,387 +1,426 @@
 {
-    "$id": "google.events.cloud.audit.v1",
-    "$schema": "http://json-schema.org/schema",
-    "title": "Cloud Audit Log LogEntry v1",
-    "name": "LogEntryData",
-    "description": "This event is triggered when a new audit log entry is written.",
-    "type": "object",
-    "goPackage": "auditv1",
-    "definitions": {
-        "MonitoredResource": {
-            "type": "object",
-            "properties": {
-                "type": {
-                    "type": "string"
-                },
-                "labels": {
-                    "type": "object"
-                }
-            }
-        },
-        "ResourceLocation": {
-            "type": "object",
-            "$comment": "https://cloud.google.com/service-infrastructure/docs/service-control/reference/rpc/google.cloud.audit?hl=en#resourcelocation",
-            "properties": {
-                "current_locations": {
-                    "description": "The locations of a resource after the execution of the operation. Requests to create or delete a location based resource must populate the 'current_locations' field and not the 'original_locations' field.",
-                    "type": "array",
-                    "items": {
-                        "type": "string",
-                        "examples": [
-                            "europe-west1-a",
-                            "us-east1",
-                            "nam3"
-                        ]
-                    }
-                },
-                "original_locations": {
-                    "description": "The locations of a resource prior to the execution of the operation. Requests that mutate the resource's location must populate both the 'original_locations' as well as the 'current_locations' fields. For example:",
-                    "type": "array",
-                    "items": {
-                        "type": "string",
-                        "examples": [
-                            "europe-west1-a",
-                            "us-east1",
-                            "nam3"
-                        ]
-                    }
-                }
-            }
-        },
-        "Status": {
-            "type": "object",
-            "properties": {
-                "code": {
-                    "type": "integer"
-                },
-                "message": {
-                    "type": "string"
-                },
-                "details": {}
-            }
-        },
-        "ServiceAccountDelegationInfo": {
-            "description": "Identity delegation history of an authenticated service account",
-            "$comment": "https://cloud.google.com/service-infrastructure/docs/service-control/reference/rpc/google.cloud.audit?hl=en#serviceaccountdelegationinfo",
-            "type": "object",
-            "oneOf": [
-                {
-                    "properties": {
-                        "principal_email": {
-                            "type": "string"
-                        },
-                        "service_metadata": {
-                            "type": "object"
-                        }
-                    }
-                },
-                {
-                    "properties": {
-                        "third_party_claims": {
-                            "type": "object"
-                        }
-                    }
-                }
-            ]
-        },
-        "AuthenticationInfo": {
-            "type": "object",
-            "description": "Authentication information for the operation.",
-            "$comment": "https://cloud.google.com/service-infrastructure/docs/service-control/reference/rpc/google.cloud.audit?hl=en#google.cloud.audit.AuthenticationInfo",
-            "properties": {
-                "principal_email": {
-                    "type": "string",
-                    "description": "The email address of the authenticated user (or service account on behalf of third party principal) making the request. For privacy reasons, the principal email address is redacted for all read-only operations that fail with a \"permission denied\" error."
-                },
-                "authority_selector": {
-                    "type": "string",
-                    "description": "The authority selector specified by the requestor, if any. It is not guaranteed that the principal was allowed to use this authority."
-                },
-                "third_party_principal": {
-                    "type": "object",
-                    "description": "The third party identification (if any) of the authenticated user making the request. When the JSON object represented here has a proto equivalent, the proto name will be indicated in the @type property."
-                },
-                "service_account_key_name": {
-                    "type": "string",
-                    "description": "The name of the service account key used to create or exchange credentials for authenticating the service account making the request. This is a scheme-less URI full resource name.",
-                    "examples": [
-                        "//iam.googleapis.com/projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}/keys/{key}"
-                    ]
-                },
-                "service_account_delegation_info": {
-                    "type": "array",
-                    "description": "Identity delegation history of an authenticated service account that makes the request. It contains information on the real authorities that try to access GCP resources by delegating on a service account. When multiple authorities present, they are guaranteed to be sorted based on the original ordering of the identity delegation events.",
-                    "items": {
-                        "$ref": "#/properties/ServiceAccountDelegationInfo"
-                    }
-                },
-                "principal_subject": {
-                    "type": "string",
-                    "description": "String representation of identity of requesting party. Populated for both first and third party identities."
-                }
-            }
-        },
-        "Resource": {
-            "type": "object",
-            "properties": {
-                "service": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "type": {
-                    "type": "string"
-                },
-                "labels": {
-                    "type": "object"
-                }
-            }
-        },
-        "AuthorizationInfo": {
-            "type": "object",
-            "$comment": "https://cloud.google.com/service-infrastructure/docs/service-control/reference/rpc/google.cloud.audit?hl=en#authorizationinfo",
-            "properties": {
-                "resource": {
-                    "type": "string",
-                    "description": "The resource being accessed, as a REST-style string.",
-                    "examples": [
-                        "bigquery.googleapis.com/projects/PROJECTID/datasets/DATASETID"
-                    ]
-                },
-                "permission": {
-                    "type": "string",
-                    "description": "The required IAM permission."
-                },
-                "granted": {
-                    "type": "boolean",
-                    "description": "Whether or not authorization for resource and permission was granted."
-                },
-                "resource_attributes": {
-                    "$ref": "#/properties/Resource",
-                    "description": "Resource attributes used in IAM condition evaluation. This field contains resource attributes like resource type and resource name. To get the whole view of the attributes used in IAM condition evaluation, the user must also look into AuditLog.request_metadata.request_attributes."
-                }
-            }
-        },
-        "Auth": {
-            "type": "object",
-            "properties": {
-                "principal": {
-                    "type": "string"
-                },
-                "audiences": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "presenter": {
-                    "type": "string"
-                },
-                "claims": {
-                    "type": "object"
-                },
-                "access_levels": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                }
-            }
-        },
-        "Request": {
-            "type": "object",
-            "properties": {
-                "id": {
-                    "type": "string"
-                },
-                "method": {
-                    "type": "string"
-                },
-                "headers": {
-                    "type": "object"
-                },
-                "path": {
-                    "type": "string"
-                },
-                "host": {
-                    "type": "string"
-                },
-                "scheme": {
-                    "type": "string"
-                },
-                "query": {
-                    "type": "string"
-                },
-                "time": {
-                    "type": "string"
-                },
-                "size": {
-                    "type": "integer"
-                },
-                "protocol": {
-                    "type": "string"
-                },
-                "reason": {
-                    "type": "string"
-                },
-                "auth": {
-                    "$ref": "#/properties/Auth"
-                }
-            }
-        },
-        "Peer": {
-            "type": "object",
-            "properties": {
-                "ip": {
-                    "type": "string"
-                },
-                "port": {
-                    "type": "integer"
-                },
-                "labels": {
-                    "type": "object"
-                },
-                "principal": {
-                    "type": "string"
-                },
-                "region_code": {
-                    "type": "string"
-                }
-            }
-        },
-        "RequestMetadata": {
-            "type": "object",
-            "properties": {
-                "caller_ip": {
-                    "type": "string"
-                },
-                "caller_supplied_user_agent": {
-                    "type": "string"
-                },
-                "caller_network": {
-                    "type": "string"
-                },
-                "request_attributes": {
-                    "$ref": "#/properties/Request"
-                },
-                "destination_attributes": {
-                    "$ref": "#/properties/Peer"
-                }
-            }
-        },
-        "AuditLog": {
-            "type": "object",
-            "properties": {
-                "service_name": {
-                    "type": "string"
-                },
-                "method_name": {
-                    "type": "string"
-                },
-                "resource_name": {
-                    "type": "string"
-                },
-                "resource_location": {
-                    "$ref": "#/properties/ResourceLocation"
-                },
-                "resource_original_state": {
-                    "type": "object"
-                },
-                "num_response_items": {
-                    "type": "integer"
-                },
-                "status": {
-                    "$ref": "#/properties/Status"
-                },
-                "authentication_info": {
-                    "$ref": "#/properties/AuthenticationInfo"
-                },
-                "authorization_info": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/properties/AuthorizationInfo"
-                    }
-                },
-                "request_metadata": {
-                    "$ref": "#/properties/RequestMetadata"
-                },
-                "request": {
-                    "type": "object"
-                },
-                "response": {
-                    "type": "object"
-                },
-                "metadata": {
-                    "type": "object"
-                },
-                "service_data": {
-                    "type": "object"
-                }
-            }
-        },
-        "LogEntryOperation": {
-            "type": "object",
-            "properties": {
-                "id": {
-                    "type": "string"
-                },
-                "producer": {
-                    "type": "string"
-                },
-                "first": {
-                    "type": "boolean"
-                },
-                "last": {
-                    "type": "boolean"
-                }
-            }
-        }
-    },
-    "properties": {
-        "log_name": {
-            "type": "string"
-        },
-        "resource": {
-            "$ref": "#/properties/MonitoredResource"
-        },
-        "proto_payload": {
-            "$ref": "#/properties/AuditLog"
-        },
-        "insert_id": {
-            "type": "string"
+  "$id": "google.events.cloud.audit.v1",
+  "$schema": "http://json-schema.org/schema",
+  "title": "Cloud Audit Log LogEntry v1",
+  "name": "LogEntryData",
+  "description": "This event is triggered when a new audit log entry is written.",
+  "type": "object",
+  "goPackage": "auditv1",
+  "definitions": {
+    "MonitoredResource": {
+      "type": "object",
+      "description": "The monitored resource that produced this log entry.",
+      "properties": {
+        "type": {
+          "description": "Required. The monitored resource type. For example, the type of a Compute Engine VM instance is `gce_instance`.",
+          "type": "string"
         },
         "labels": {
-            "type": "object"
-        },
-        "operation": {
-            "$ref": "#/properties/LogEntryOperation"
-        },
-        "timestamp": {
-            "type": "string"
-        },
-        "receive_timestamp": {
-            "type": "string"
-        },
-        "severity": {
-            "type": "integer",
-            "enum": [
-                0,
-                100,
-                200,
-                300,
-                400,
-                500,
-                600,
-                700,
-                800
-            ]
-        },
-        "trace": {
-            "type": "string"
-        },
-        "span_id": {
-            "type": "string"
+          "description": "Values for all of the labels listed in the associated monitored resource descriptor. For example, Compute Engine VM instances use the labels `\"project_id\"`, `\"instance_id\"`, and `\"zone\"`.",
+          "type": "object"
         }
+      }
+    },
+    "ResourceLocation": {
+      "type": "object",
+      "$comment": "https://cloud.google.com/service-infrastructure/docs/service-control/reference/rpc/google.cloud.audit?hl=en#resourcelocation",
+      "description": "Location information about a resource.",
+      "properties": {
+        "current_locations": {
+          "description": "The locations of a resource after the execution of the operation. Requests to create or delete a location based resource must populate the 'current_locations' field and not the 'original_locations' field.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "examples": [
+              "europe-west1-a",
+              "us-east1",
+              "nam3"
+            ]
+          }
+        },
+        "original_locations": {
+          "description": "The locations of a resource prior to the execution of the operation. Requests that mutate the resource's location must populate both the 'original_locations' as well as the 'current_locations' fields. For example:",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "examples": [
+              "europe-west1-a",
+              "us-east1",
+              "nam3"
+            ]
+          }
+        }
+      }
+    },
+    "Status": {
+      "type": "object",
+      "description": "The status of the overall operation.",
+      "properties": {
+        "code": {
+          "description": "The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].",
+          "type": "integer"
+        },
+        "message": {
+          "description": "A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.",
+          "type": "string"
+        },
+        "details": {
+          "description": "A list of messages that carry the error details.  There is a common set of message types for APIs to use."
+        }
+      }
+    },
+    "ServiceAccountDelegationInfo": {
+      "description": "Identity delegation history of an authenticated service account",
+      "$comment": "https://cloud.google.com/service-infrastructure/docs/service-control/reference/rpc/google.cloud.audit?hl=en#serviceaccountdelegationinfo",
+      "type": "object",
+      "oneOf": [
+        {
+          "properties": {
+            "principal_email": {
+              "description": "The email address of a Google account.",
+              "type": "string"
+            },
+            "service_metadata": {
+              "description": "Metadata about the service that uses the service account.",
+              "type": "object"
+            }
+          }
+        },
+        {
+          "properties": {
+            "third_party_claims": {
+              "description": "Metadata about third party identity.",
+              "type": "object"
+            }
+          }
+        }
+      ]
+    },
+    "AuthenticationInfo": {
+      "type": "object",
+      "description": "Authentication information for the operation.",
+      "$comment": "https://cloud.google.com/service-infrastructure/docs/service-control/reference/rpc/google.cloud.audit?hl=en#google.cloud.audit.AuthenticationInfo",
+      "properties": {
+        "principal_email": {
+          "type": "string",
+          "description": "The email address of the authenticated user (or service account on behalf of third party principal) making the request. For privacy reasons, the principal email address is redacted for all read-only operations that fail with a \"permission denied\" error."
+        },
+        "authority_selector": {
+          "type": "string",
+          "description": "The authority selector specified by the requestor, if any. It is not guaranteed that the principal was allowed to use this authority."
+        },
+        "third_party_principal": {
+          "type": "object",
+          "description": "The third party identification (if any) of the authenticated user making the request. When the JSON object represented here has a proto equivalent, the proto name will be indicated in the @type property."
+        },
+        "service_account_key_name": {
+          "type": "string",
+          "description": "The name of the service account key used to create or exchange credentials for authenticating the service account making the request. This is a scheme-less URI full resource name.",
+          "examples": [
+            "//iam.googleapis.com/projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}/keys/{key}"
+          ]
+        },
+        "service_account_delegation_info": {
+          "type": "array",
+          "description": "Identity delegation history of an authenticated service account that makes the request. It contains information on the real authorities that try to access GCP resources by delegating on a service account. When multiple authorities present, they are guaranteed to be sorted based on the original ordering of the identity delegation events.",
+          "items": {
+            "$ref": "#/definitions/ServiceAccountDelegationInfo"
+          }
+        },
+        "principal_subject": {
+          "type": "string",
+          "description": "String representation of identity of requesting party. Populated for both first and third party identities."
+        }
+      }
+    },
+    "Resource": {
+      "type": "object",
+      "properties": {
+        "service": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "labels": {
+          "type": "object"
+        }
+      }
+    },
+    "AuthorizationInfo": {
+      "type": "object",
+      "$comment": "https://cloud.google.com/service-infrastructure/docs/service-control/reference/rpc/google.cloud.audit?hl=en#authorizationinfo",
+      "description": "Authorization information. If there are multiple resources or permissions involved, then there is one AuthorizationInfo element for each {resource, permission} tuple.",
+      "properties": {
+        "resource": {
+          "type": "string",
+          "description": "The resource being accessed, as a REST-style string.",
+          "examples": [
+            "bigquery.googleapis.com/projects/PROJECTID/datasets/DATASETID"
+          ]
+        },
+        "permission": {
+          "type": "string",
+          "description": "The required IAM permission."
+        },
+        "granted": {
+          "type": "boolean",
+          "description": "Whether or not authorization for resource and permission was granted."
+        },
+        "resource_attributes": {
+          "$ref": "#/definitions/Resource",
+          "description": "Resource attributes used in IAM condition evaluation. This field contains resource attributes like resource type and resource name. To get the whole view of the attributes used in IAM condition evaluation, the user must also look into AuditLog.request_metadata.request_attributes."
+        }
+      }
+    },
+    "Auth": {
+      "type": "object",
+      "properties": {
+        "principal": {
+          "type": "string"
+        },
+        "audiences": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "presenter": {
+          "type": "string"
+        },
+        "claims": {
+          "type": "object"
+        },
+        "access_levels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Request": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "method": {
+          "type": "string"
+        },
+        "headers": {
+          "type": "object"
+        },
+        "path": {
+          "type": "string"
+        },
+        "host": {
+          "type": "string"
+        },
+        "scheme": {
+          "type": "string"
+        },
+        "query": {
+          "type": "string"
+        },
+        "time": {
+          "type": "string"
+        },
+        "size": {
+          "type": "integer"
+        },
+        "protocol": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "auth": {
+          "$ref": "#/definitions/Auth"
+        }
+      }
+    },
+    "Peer": {
+      "type": "object",
+      "properties": {
+        "ip": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer"
+        },
+        "labels": {
+          "type": "object"
+        },
+        "principal": {
+          "type": "string"
+        },
+        "region_code": {
+          "type": "string"
+        }
+      }
+    },
+    "RequestMetadata": {
+      "type": "object",
+      "description": "Metadata about the operation.",
+      "properties": {
+        "caller_ip": {
+          "type": "string",
+          "description":  "The IP address of the caller. For caller from internet, this will be public IPv4 or IPv6 address. For caller from a Compute Engine VM with external IP address, this will be the VM's external IP address. For caller from a Compute Engine VM without external IP address, if the VM is in the same organization (or project) as the accessed resource, `caller_ip` will be the VM's internal IPv4 address, otherwise the `caller_ip` will be redacted to \"gce-internal-ip\". See https://cloud.google.com/compute/docs/vpc/ for more information.\""
+        },
+        "caller_supplied_user_agent": {
+          "type": "string",
+          "description": "The user agent of the caller. This information is not authenticated and should be treated accordingly."
+        },
+        "caller_network": {
+          "type": "string",
+          "description": "The network of the caller."
+        },
+        "request_attributes": {
+          "$ref": "#/definitions/Request",
+          "description": "Request attributes used in IAM condition evaluation. This field contains request attributes like request time and access levels associated with the request."
+        },
+        "destination_attributes": {
+          "$ref": "#/definitions/Peer",
+          "description": "The destination of a network activity, such as accepting a TCP connection."
+        }
+      }
+    },
+    "AuditLog": {
+      "type": "object",
+      "description": "The log entry payload, which is always an AuditLog for Cloud Audit Log events.",
+      "properties": {
+        "service_name": {
+          "type": "string",
+          "description": "The name of the API service performing the operation. For example, `\"datastore.googleapis.com\"`."
+        },
+        "method_name": {
+          "type": "string",
+          "description": "The name of the service method or operation. For example \"google.datastore.v1.Datastore.RunQuery\""
+        },
+        "resource_name": {
+          "type": "string",
+          "description": "The resource or collection that is the target of the operation. For example \"shelves/SHELF_ID/books\""
+        },
+        "resource_location": {
+          "$ref": "#/definitions/ResourceLocation",
+          "description": "The resource location information."
+        },
+        "resource_original_state": {
+          "type": "object",
+          "description": "The resource's original state before mutation."
+        },
+        "num_response_items": {
+          "type": "integer",
+          "description": "The number of items returned from a List or Query API method, if applicable."
+        },
+        "status": {
+          "$ref": "#/definitions/Status",
+          "description": "The status of the overall operation."
+        },
+        "authentication_info": {
+          "$ref": "#/definitions/AuthenticationInfo",
+          "description": "Authentication information."
+        },
+        "authorization_info": {
+          "type": "array",
+          "description": "Authorization information. If there are multiple resources or permissions involved, then there is one AuthorizationInfo element for each {resource, permission} tuple.",
+          "items": {
+            "$ref": "#/definitions/AuthorizationInfo"
+          }
+        },
+        "request_metadata": {
+          "description": "Metadata about the operation.",
+          "$ref": "#/definitions/RequestMetadata"
+        },
+        "request": {
+          "description": "The operation request. This may not include all request parameters, such as those that are too large, privacy-sensitive, or duplicated elsewhere in the log record. It should never include user-generated data, such as file contents. When the JSON object represented here has a proto equivalent, the proto name will be indicated in the `@type` property.",
+          "type": "object"
+        },
+        "response": {
+          "type": "object",
+          "description": "The operation response. This may not include all response elements, such as those that are too large, privacy-sensitive, or duplicated elsewhere in the log record. It should never include user-generated data, such as file contents. When the JSON object represented here has a proto equivalent, the proto name will be indicated in the `@type` property."
+        },
+        "metadata": {
+          "type": "object",
+          "description": "Other service-specific data about the request, response, and other information associated with the current audited event."
+        },
+        "service_data": {
+          "type": "object",
+          "description": "Deprecated, use `metadata` field instead. Other service-specific data about the request, response, and other activities. When the JSON object represented here has a proto equivalent, the proto name will be indicated in the `@type` property."
+        }
+      }
+    },
+    "LogEntryOperation": {
+      "type": "object",
+      "description": "Additional information about a potentially long-running operation with which a log entry is associated.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "An arbitrary operation identifier. Log entries with the same identifier are assumed to be part of the same operation."
+        },
+        "producer": {
+          "type": "string",
+          "description": "An arbitrary producer identifier. The combination of `id` and `producer` must be globally unique. Examples for `producer`: `\"MyDivision.MyBigCompany.com\"`, `\"github.com/MyProject/MyApplication\"`."
+        },
+        "first": {
+          "type": "boolean",
+          "description": "True if this is the first log entry in the operation."
+        },
+        "last": {
+          "type": "boolean",
+          "description": "True if this is the last log entry in the operation."
+        }
+      }
     }
+  },
+  "properties": {
+    "log_name": {
+      "type": "string",
+      "description": "The resource name of the log to which this log entry belongs."
+    },
+    "resource": {
+      "description": "The monitored resource that produced this log entry. Example: a log entry that reports a database error would be associated with the monitored resource designating the particular database that reported the error.",
+      "$ref": "#/definitions/MonitoredResource"
+    },
+    "proto_payload": {
+      "description": "The log entry payload, which is always an AuditLog for Cloud Audit Log events.",
+      "$ref": "#/definitions/AuditLog"
+    },
+    "insert_id": {
+      "description": "A unique identifier for the log entry. ",
+      "type": "string"
+    },
+    "labels": {
+      "description": "A set of user-defined (key, value) data that provides additional information about the log entry.",
+      "type": "object"
+    },
+    "operation": {
+      "description": "Information about an operation associated with the log entry, if applicable.",
+      "$ref": "#/definitions/LogEntryOperation"
+    },
+    "timestamp": {
+      "description": "The time the event described by the log entry occurred.",
+      "type": "string"
+    },
+    "receive_timestamp": {
+      "description": "The time the log entry was received by Logging.",
+      "type": "string"
+    },
+    "severity": {
+      "description": "The severity of the log entry.",
+      "type": "string"
+    },
+    "trace": {
+      "description": "Resource name of the trace associated with the log entry, if any. If it contains a relative resource name, the name is assumed to be relative to `//tracing.googleapis.com`. Example: `projects/my-projectid/traces/06796866738c859f2f19b7cfb3214824`",
+      "type": "string"
+    },
+    "span_id": {
+      "description": "The span ID within the trace associated with the log entry, if any. For Trace spans, this is the same format that the Trace API v2 uses: a 16-character hexadecimal encoding of an 8-byte array, such as `000000000000004a`.",
+      "type": "string"
+    }
+  }
 }

--- a/proto/google/events/cloud/pubsub/v1/MessagePublishedData.json
+++ b/proto/google/events/cloud/pubsub/v1/MessagePublishedData.json
@@ -1,40 +1,40 @@
 {
-    "$id": "google.events.cloud.pubsub.v1",
-    "$schema": "http://json-schema.org/schema",
-    "title": "Cloud Pub/Sub Message v1",
-    "name": "MessagePublishedData",
-    "description": "A message that is published by publishers and consumed by subscribers.",
-    "type": "object",
-    "goPackage": "pubsubv1",
-    "definitions": {
-        "PubsubMessage": {
-            "type": "object",
-            "$comment": "https://cloud.google.com/pubsub/docs/reference/rest/v1/PubsubMessage",
-            "description": "A message published to a topic.",
-            "properties": {
-                "data": {
-                    "description": "The message data field. If this field is empty, the message must contain at least one attribute. A base64-encoded string.",
-                    "type": "string",
-                    "format": "binary"
-                },
-                "attributes": {
-                    "description": "Attributes for this message. If this field is empty, the message must contain non-empty data. This can be used to filter messages on the subscription.",
-                    "type": "object"
-                },
-                "messageId": {
-                    "description": "ID of this message, assigned by the server when the message is published. Guaranteed to be unique within the topic. This value may be read by a subscriber that receives a PubsubMessage via a subscriptions.pull call or a push delivery. It must not be populated by the publisher in a topics.publish call.",
-                    "type": "string"
-                }
-            }
-        }
-    },
-    "properties": {
-        "message": {
-            "$ref": "#/definitions/PubsubMessage"
+  "$id": "google.events.cloud.pubsub.v1",
+  "$schema": "http://json-schema.org/schema",
+  "title": "Cloud Pub/Sub Message v1",
+  "name": "MessagePublishedData",
+  "description": "A message that is published by publishers and consumed by subscribers.",
+  "type": "object",
+  "goPackage": "pubsubv1",
+  "definitions": {
+    "PubsubMessage": {
+      "type": "object",
+      "$comment": "https://cloud.google.com/pubsub/docs/reference/rest/v1/PubsubMessage",
+      "description": "A message published to a topic.",
+      "properties": {
+        "data": {
+          "description": "The message data field. If this field is empty, the message must contain at least one attribute. A base64-encoded string.",
+          "type": "string",
+          "format": "binary"
         },
-        "subscription": {
-            "description": "The resource name of the subscription for which this event was generated. The format of the value is `projects/{project-id}/subscriptions/{subscription-id}`.",
-            "type": "string"
+        "attributes": {
+          "description": "Attributes for this message. If this field is empty, the message must contain non-empty data. This can be used to filter messages on the subscription.",
+          "type": "object"
+        },
+        "messageId": {
+          "description": "ID of this message, assigned by the server when the message is published. Guaranteed to be unique within the topic. This value may be read by a subscriber that receives a PubsubMessage via a subscriptions.pull call or a push delivery. It must not be populated by the publisher in a topics.publish call.",
+          "type": "string"
         }
+      }
     }
+  },
+  "properties": {
+    "message": {
+      "$ref": "#/definitions/PubsubMessage"
+    },
+    "subscription": {
+      "description": "The resource name of the subscription for which this event was generated. The format of the value is `projects/{project-id}/subscriptions/{subscription-id}`.",
+      "type": "string"
+    }
+  }
 }


### PR DESCRIPTION
Fixes #66. There were a few mistakes with the JSON Schema (specifically the references). VS Code and JSONSchema editors have nice tooling for go-to-defintion and schema errors.

- Completes JSON Schema descriptions (manually from the proto source – yes this should be automatic at some point)
- Changes indentation to 2 spaces for more standard json indentation (sorry for the poor diff)
- Fixes some of the invalid schema references

Reference errors were detected and fixed with this tool:

https://www.jsonschemavalidator.net/

---

This should give better IDE descriptions. Will work on patching the QuickType wrapper in parallel to this.