### PR TITLE
fix: change cal jsonschema to use camelCase

### DIFF
--- a/jsonschema/google/events/cloud/audit/v1/LogEntryData.json
+++ b/jsonschema/google/events/cloud/audit/v1/LogEntryData.json
@@ -12,11 +12,11 @@
       "description": "The monitored resource that produced this log entry.",
       "properties": {
         "type": {
-          "description": "Required. The monitored resource type. For example, the type of a Compute Engine VM instance is `gce_instance`.",
+          "description": "Required. The monitored resource type. For example, the type of a Compute Engine VM instance is `gceInstance`.",
           "type": "string"
         },
         "labels": {
-          "description": "Values for all of the labels listed in the associated monitored resource descriptor. For example, Compute Engine VM instances use the labels `\"project_id\"`, `\"instance_id\"`, and `\"zone\"`.",
+          "description": "Values for all of the labels listed in the associated monitored resource descriptor. For example, Compute Engine VM instances use the labels `\"projectId\"`, `\"instanceId\"`, and `\"zone\"`.",
           "type": "object"
         }
       }
@@ -26,8 +26,8 @@
       "$comment": "https://cloud.google.com/service-infrastructure/docs/service-control/reference/rpc/google.cloud.audit?hl=en#resourcelocation",
       "description": "Location information about a resource.",
       "properties": {
-        "current_locations": {
-          "description": "The locations of a resource after the execution of the operation. Requests to create or delete a location based resource must populate the 'current_locations' field and not the 'original_locations' field.",
+        "currentLocations": {
+          "description": "The locations of a resource after the execution of the operation. Requests to create or delete a location based resource must populate the 'currentLocations' field and not the 'originalLocations' field.",
           "type": "array",
           "items": {
             "type": "string",
@@ -38,8 +38,8 @@
             ]
           }
         },
-        "original_locations": {
-          "description": "The locations of a resource prior to the execution of the operation. Requests that mutate the resource's location must populate both the 'original_locations' as well as the 'current_locations' fields. For example:",
+        "originalLocations": {
+          "description": "The locations of a resource prior to the execution of the operation. Requests that mutate the resource's location must populate both the 'originalLocations' as well as the 'currentLocations' fields. For example:",
           "type": "array",
           "items": {
             "type": "string",
@@ -76,11 +76,11 @@
       "oneOf": [
         {
           "properties": {
-            "principal_email": {
+            "principalEmail": {
               "description": "The email address of a Google account.",
               "type": "string"
             },
-            "service_metadata": {
+            "serviceMetadata": {
               "description": "Metadata about the service that uses the service account.",
               "type": "object"
             }
@@ -88,7 +88,7 @@
         },
         {
           "properties": {
-            "third_party_claims": {
+            "thirdPartyClaims": {
               "description": "Metadata about third party identity.",
               "type": "object"
             }
@@ -101,33 +101,33 @@
       "description": "Authentication information for the operation.",
       "$comment": "https://cloud.google.com/service-infrastructure/docs/service-control/reference/rpc/google.cloud.audit?hl=en#google.cloud.audit.AuthenticationInfo",
       "properties": {
-        "principal_email": {
+        "principalEmail": {
           "type": "string",
           "description": "The email address of the authenticated user (or service account on behalf of third party principal) making the request. For privacy reasons, the principal email address is redacted for all read-only operations that fail with a \"permission denied\" error."
         },
-        "authority_selector": {
+        "authoritySelector": {
           "type": "string",
           "description": "The authority selector specified by the requestor, if any. It is not guaranteed that the principal was allowed to use this authority."
         },
-        "third_party_principal": {
+        "thirdPartyPrincipal": {
           "type": "object",
           "description": "The third party identification (if any) of the authenticated user making the request. When the JSON object represented here has a proto equivalent, the proto name will be indicated in the @type property."
         },
-        "service_account_key_name": {
+        "serviceAccountKeyName": {
           "type": "string",
           "description": "The name of the service account key used to create or exchange credentials for authenticating the service account making the request. This is a scheme-less URI full resource name.",
           "examples": [
             "//iam.googleapis.com/projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}/keys/{key}"
           ]
         },
-        "service_account_delegation_info": {
+        "serviceAccountDelegationInfo": {
           "type": "array",
           "description": "Identity delegation history of an authenticated service account that makes the request. It contains information on the real authorities that try to access GCP resources by delegating on a service account. When multiple authorities present, they are guaranteed to be sorted based on the original ordering of the identity delegation events.",
           "items": {
             "$ref": "#/definitions/ServiceAccountDelegationInfo"
           }
         },
-        "principal_subject": {
+        "principalSubject": {
           "type": "string",
           "description": "String representation of identity of requesting party. Populated for both first and third party identities."
         }
@@ -170,9 +170,9 @@
           "type": "boolean",
           "description": "Whether or not authorization for resource and permission was granted."
         },
-        "resource_attributes": {
+        "resourceAttributes": {
           "$ref": "#/definitions/Resource",
-          "description": "Resource attributes used in IAM condition evaluation. This field contains resource attributes like resource type and resource name. To get the whole view of the attributes used in IAM condition evaluation, the user must also look into AuditLog.request_metadata.request_attributes."
+          "description": "Resource attributes used in IAM condition evaluation. This field contains resource attributes like resource type and resource name. To get the whole view of the attributes used in IAM condition evaluation, the user must also look into AuditLog.requestMetadata.requestAttributes."
         }
       }
     },
@@ -194,7 +194,7 @@
         "claims": {
           "type": "object"
         },
-        "access_levels": {
+        "accessLevels": {
           "type": "array",
           "items": {
             "type": "string"
@@ -258,7 +258,7 @@
         "principal": {
           "type": "string"
         },
-        "region_code": {
+        "regionCode": {
           "type": "string"
         }
       }
@@ -267,23 +267,23 @@
       "type": "object",
       "description": "Metadata about the operation.",
       "properties": {
-        "caller_ip": {
+        "callerIp": {
           "type": "string",
-          "description":  "The IP address of the caller. For caller from internet, this will be public IPv4 or IPv6 address. For caller from a Compute Engine VM with external IP address, this will be the VM's external IP address. For caller from a Compute Engine VM without external IP address, if the VM is in the same organization (or project) as the accessed resource, `caller_ip` will be the VM's internal IPv4 address, otherwise the `caller_ip` will be redacted to \"gce-internal-ip\". See https://cloud.google.com/compute/docs/vpc/ for more information.\""
+          "description":  "The IP address of the caller. For caller from internet, this will be public IPv4 or IPv6 address. For caller from a Compute Engine VM with external IP address, this will be the VM's external IP address. For caller from a Compute Engine VM without external IP address, if the VM is in the same organization (or project) as the accessed resource, `callerIp` will be the VM's internal IPv4 address, otherwise the `callerIp` will be redacted to \"gce-internal-ip\". See https://cloud.google.com/compute/docs/vpc/ for more information.\""
         },
-        "caller_supplied_user_agent": {
+        "callerSuppliedUserAgent": {
           "type": "string",
           "description": "The user agent of the caller. This information is not authenticated and should be treated accordingly."
         },
-        "caller_network": {
+        "callerNetwork": {
           "type": "string",
           "description": "The network of the caller."
         },
-        "request_attributes": {
+        "requestAttributes": {
           "$ref": "#/definitions/Request",
           "description": "Request attributes used in IAM condition evaluation. This field contains request attributes like request time and access levels associated with the request."
         },
-        "destination_attributes": {
+        "destinationAttributes": {
           "$ref": "#/definitions/Peer",
           "description": "The destination of a network activity, such as accepting a TCP connection."
         }
@@ -293,27 +293,27 @@
       "type": "object",
       "description": "The log entry payload, which is always an AuditLog for Cloud Audit Log events.",
       "properties": {
-        "service_name": {
+        "serviceName": {
           "type": "string",
           "description": "The name of the API service performing the operation. For example, `\"datastore.googleapis.com\"`."
         },
-        "method_name": {
+        "methodName": {
           "type": "string",
           "description": "The name of the service method or operation. For example \"google.datastore.v1.Datastore.RunQuery\""
         },
-        "resource_name": {
+        "resourceName": {
           "type": "string",
           "description": "The resource or collection that is the target of the operation. For example \"shelves/SHELF_ID/books\""
         },
-        "resource_location": {
+        "resourceLocation": {
           "$ref": "#/definitions/ResourceLocation",
           "description": "The resource location information."
         },
-        "resource_original_state": {
+        "resourceOriginalState": {
           "type": "object",
           "description": "The resource's original state before mutation."
         },
-        "num_response_items": {
+        "numResponseItems": {
           "type": "integer",
           "description": "The number of items returned from a List or Query API method, if applicable."
         },
@@ -321,18 +321,18 @@
           "$ref": "#/definitions/Status",
           "description": "The status of the overall operation."
         },
-        "authentication_info": {
+        "authenticationInfo": {
           "$ref": "#/definitions/AuthenticationInfo",
           "description": "Authentication information."
         },
-        "authorization_info": {
+        "authorizationInfo": {
           "type": "array",
           "description": "Authorization information. If there are multiple resources or permissions involved, then there is one AuthorizationInfo element for each {resource, permission} tuple.",
           "items": {
             "$ref": "#/definitions/AuthorizationInfo"
           }
         },
-        "request_metadata": {
+        "requestMetadata": {
           "description": "Metadata about the operation.",
           "$ref": "#/definitions/RequestMetadata"
         },
@@ -348,7 +348,7 @@
           "type": "object",
           "description": "Other service-specific data about the request, response, and other information associated with the current audited event."
         },
-        "service_data": {
+        "serviceData": {
           "type": "object",
           "description": "Deprecated, use `metadata` field instead. Other service-specific data about the request, response, and other activities. When the JSON object represented here has a proto equivalent, the proto name will be indicated in the `@type` property."
         }
@@ -378,7 +378,7 @@
     }
   },
   "properties": {
-    "log_name": {
+    "logName": {
       "type": "string",
       "description": "The resource name of the log to which this log entry belongs."
     },
@@ -386,11 +386,11 @@
       "description": "The monitored resource that produced this log entry. Example: a log entry that reports a database error would be associated with the monitored resource designating the particular database that reported the error.",
       "$ref": "#/definitions/MonitoredResource"
     },
-    "proto_payload": {
+    "protoPayload": {
       "description": "The log entry payload, which is always an AuditLog for Cloud Audit Log events.",
       "$ref": "#/definitions/AuditLog"
     },
-    "insert_id": {
+    "insertId": {
       "description": "A unique identifier for the log entry. ",
       "type": "string"
     },
@@ -406,7 +406,7 @@
       "description": "The time the event described by the log entry occurred.",
       "type": "string"
     },
-    "receive_timestamp": {
+    "receiveTimestamp": {
       "description": "The time the log entry was received by Logging.",
       "type": "string"
     },
@@ -418,7 +418,7 @@
       "description": "Resource name of the trace associated with the log entry, if any. If it contains a relative resource name, the name is assumed to be relative to `//tracing.googleapis.com`. Example: `projects/my-projectid/traces/06796866738c859f2f19b7cfb3214824`",
       "type": "string"
     },
-    "span_id": {
+    "spanId": {
       "description": "The span ID within the trace associated with the log entry, if any. For Trace spans, this is the same format that the Trace API v2 uses: a 16-character hexadecimal encoding of an 8-byte array, such as `000000000000004a`.",
       "type": "string"
     }


### PR DESCRIPTION
Modifies the JSON Schema field keys to use camelCase as provided by the Eventarc API, but not the representation used in protos.

See:
- go/proto3-json-spec
- https://developers.google.com/protocol-buffers/docs/proto3#json_options