### PR TITLE
feat: support multi-file exports for qt

### DIFF
--- a/tools/quicktype-wrapper/src/index.ts
+++ b/tools/quicktype-wrapper/src/index.ts
@@ -1,7 +1,13 @@
 #!/usr/bin/env node
 
 import { readFileSync, writeFileSync } from "fs";
-import {jsonschema2language, LANGUAGE, LANGUAGE_EXT, TARGET_LANGUAGE} from './quickstype';
+import {
+  jsonschema2languageFiles,
+  LANGUAGE,
+  LANGUAGE_EXT,
+  TARGET_LANGUAGE,
+  QtMultifileResult,
+} from './quickstype';
 const {argv} = require('yargs')
 const mkdirp = require('mkdirp');
 const recursive = require("recursive-readdir");
@@ -33,33 +39,6 @@ async function getJSONSchemasPaths(directory: string) {
   return paths;
 }
 
-/**
- * Gets a list of tuples of all JSON schemas and code generated from them
- * @param directory The path to the directory with schemas.
- * @param language The language of the code.
- */
-export async function getJSONSchemasAndGenFiles(directory: string, language: string) {
-  const absPaths = await getJSONSchemasPaths(directory);
-
-  let schemasAndGenFiles: Array<[object, string]> = [];
-
-  const promises = absPaths.map(async (f: string, i: number) => {
-    const file = readFileSync(f) + '';
-    const schema = JSON.parse(file);
-    const genFile = await jsonschema2language({
-      jsonSchema: file,
-      language: language,
-      typeName: "Event"
-    })
-
-    schemasAndGenFiles.push([schema, genFile]);
-  });
-
-  await Promise.all(promises);
-
-  return schemasAndGenFiles;
-}
-
 // Start the program
 if (!module.parent) {
   (async () => {
@@ -86,36 +65,70 @@ if (!module.parent) {
     const relPaths = absPaths.map((p: string) => {
       return p.substr(IN.length);
     });
-    console.log(`Found ${absPaths.length} schema(s).`);
+
+    // List schemas found
+    console.log(`Found ${absPaths.length} schema(s):`);
+    relPaths.forEach(path => console.log(`- ${path}`));
+    console.log();
 
     // Loop through every path
     const pathPromises = absPaths.map(async (f: string, i: number) => {
-      const file = await readFileSync(f) + '';
+      const file = readFileSync(f) + '';
       const pathToSchema = relPaths[i]; // e.g. /google/events/cloud/pubsub/MessagePublishedData.json
       const typeName = JSON.parse(file).name; // e.g. MessagePublishedData
 
-      // Generate language file using quicktype
-      const genFile = await jsonschema2language({
+      // Generate language file(s) using quicktype
+      const genFiles: QtMultifileResult = await jsonschema2languageFiles({
         jsonSchema: file,
         language: L,
         typeName,
       });
-      
-      // Save the language file with the right filename.
-      // fullPathTargetFile: /google/events/cloud/pubsub/MessagePublishedData.ts 
-      const fullPathTargetFile = pathToSchema.replace('.json', `.${LANGUAGE_EXT[L]}`);
-      // relativePathTargetFile: cloud/pubsub/MessagePublishedData.ts 
-      const relativePathTargetFile = fullPathTargetFile.substr('/google/events/'.length);
-      // relativePathTargetDirectory: cloud/pubsub/
-      const relativePathTargetDirectory = relativePathTargetFile.substring(
-        0, relativePathTargetFile.lastIndexOf('/'));
 
-      // Create the directory
-      await mkdirp(relativePathTargetDirectory);
-      writeFileSync(relativePathTargetFile, genFile);
-      console.log(`- ${typeName.padEnd(40, ' ')}: ${relativePathTargetFile}`);
+      // For each type file...
+      // Keep a stdout buffer per type to not intertwine output
+      const bufferedOutput: string[] = [
+        `## Generating files for ${typeName}...`
+      ];
+      for (const [filename, filecontents] of Object.entries(genFiles)) {
+        const relativePathTargetDirectory = pathToSchema.substring(
+          0, pathToSchema.lastIndexOf('/'));
+
+        // This next if statement handles if Quicktype generated one or many files
+        if (filename === 'stdout') {
+          // For languages that just produce one file, Quicktype output filename is 'stdout'.
+          const relativeFilePath = `${relativePathTargetDirectory}/${filename}`;
+          const absFilePathDir = `${OUT}/${relativePathTargetDirectory}`;
+
+          // Create dir
+          await mkdirp(absFilePathDir);
+
+          // Write file
+          const typeFilename = `${typeName}.${LANGUAGE_EXT[L]}`;
+          const absFilePath = `${absFilePathDir}/${typeFilename}`;
+          writeFileSync(absFilePath, filecontents);
+          bufferedOutput.push(`- ${typeFilename.padEnd(40, ' ')}: ${relativeFilePath}/${typeFilename}`);
+        } else {
+          // Otherwise, the Quicktype result produced multiple type files from the schema.
+          const relativeFilePath = `${relativePathTargetDirectory}/${filename}`;
+          const absFilePath = `${OUT}/${relativeFilePath}`;
+
+          // Create dir
+          const absFilePathDir = absFilePath.substring(0, absFilePath.lastIndexOf('/'));
+          await mkdirp(absFilePathDir);
+
+          // For languages that just produce N files, quicktype output is (filename, filecontents).
+          // Write file
+          writeFileSync(absFilePath, filecontents);
+          bufferedOutput.push(`- ${filename.padEnd(40, ' ')}: ${relativeFilePath}`);
+        }
+      }
+
+      // Write all of the output in order.
+      bufferedOutput.forEach((s) => console.log(s));
     });
+
+    // Await all promises to resolve and write "END" when the program is done.
     await Promise.all(pathPromises);
     console.log('== END ==');
   })();
-};
+}

--- a/tools/quicktype-wrapper/src/quickstype.ts
+++ b/tools/quicktype-wrapper/src/quickstype.ts
@@ -6,50 +6,50 @@ import {
   FetchingJSONSchemaStore,
 } from 'quicktype-core';
 // Interface not exported in top-level 'quicktype-core': https://github.com/quicktype/quicktype/pull/1565
-import {MultiFileRenderResult} from '../node_modules/quicktype-core/dist/TargetLanguage'
+import {MultiFileRenderResult} from '../node_modules/quicktype-core/dist/TargetLanguage';
 
 /**
  * A list of supported Quicktype languages.
  * @see https://github.com/quicktype/quicktype/tree/master/src/quicktype-core/language
  */
 export const LANGUAGE = {
-  CSHARP: "csharp",
-  JAVA: "java",
-  PYTHON: "python",
-  RUST: "rust",
-  CRYSTAL: "crystal",
-  RUBY: "ruby",
-  GOLANG: "golang",
-  CPLUSPLUS: "cplusplus",
-  ELM: "elm",
-  SWIFT: "swift",
-  OBJECTIVEC: "objective-c",
-  TYPESCRIPT: "typescript",
-  JAVASCRIPT: "javascript",
-  KOTLIN: "kotlin",
-  DART: "dart",
-  PIKE: "pike",
-  HASKELL: "haskell",
+  CSHARP: 'csharp',
+  JAVA: 'java',
+  PYTHON: 'python',
+  RUST: 'rust',
+  CRYSTAL: 'crystal',
+  RUBY: 'ruby',
+  GOLANG: 'golang',
+  CPLUSPLUS: 'cplusplus',
+  ELM: 'elm',
+  SWIFT: 'swift',
+  OBJECTIVEC: 'objective-c',
+  TYPESCRIPT: 'typescript',
+  JAVASCRIPT: 'javascript',
+  KOTLIN: 'kotlin',
+  DART: 'dart',
+  PIKE: 'pike',
+  HASKELL: 'haskell',
 };
 export type TARGET_LANGUAGE = keyof typeof LANGUAGE;
 export const LANGUAGE_EXT = {
-  CSHARP: "cs",
-  JAVA: "java",
-  PYTHON: "py",
-  RUST: "rs",
-  CRYSTAL: "cr",
-  RUBY: "rb",
-  GOLANG: "go",
-  CPLUSPLUS: "cpp",
-  ELM: "elm",
-  SWIFT: "swift",
-  OBJECTIVEC: "m",
-  TYPESCRIPT: "ts",
-  JAVASCRIPT: "js",
-  KOTLIN: "kt",
-  DART: "dart",
-  PIKE: "pike",
-  HASKELL: "hs",
+  CSHARP: 'cs',
+  JAVA: 'java',
+  PYTHON: 'py',
+  RUST: 'rs',
+  CRYSTAL: 'cr',
+  RUBY: 'rb',
+  GOLANG: 'go',
+  CPLUSPLUS: 'cpp',
+  ELM: 'elm',
+  SWIFT: 'swift',
+  OBJECTIVEC: 'm',
+  TYPESCRIPT: 'ts',
+  JAVASCRIPT: 'js',
+  KOTLIN: 'kt',
+  DART: 'dart',
+  PIKE: 'pike',
+  HASKELL: 'hs',
 };
 
 /**
@@ -77,11 +77,15 @@ async function quicktypeJSONSchemaToMultiFile(
   return await quicktypeMultiFile({
     inputData,
     lang,
+    rendererOptions: {
+      // Don't generate Jackson types
+      'just-types': 'true',
+    },
   });
 }
 
 // A simple map from filename to file contents.
-export type QtMultifileResult = { [filename: string]: string };
+export type QtMultifileResult = {[filename: string]: string};
 
 /**
  * Converts a JSON Schema file (string) to a set of langauge files.
@@ -104,14 +108,16 @@ export async function jsonschema2languageFiles({
     typeName,
     jsonSchema
   );
-  const multifileResultList: [string, SerializedRenderResult][] = Array.from(multifileResult.entries());
+  const multifileResultList: [string, SerializedRenderResult][] = Array.from(
+    multifileResult.entries()
+  );
 
   // Transform result to a map of filepath : file contents
   const multifileResultMap: QtMultifileResult = {};
-  multifileResultList.forEach((singleFile => {
+  multifileResultList.forEach(singleFile => {
     const [filename, renderResult] = singleFile;
     const fileContents = renderResult.lines.join('\n');
     multifileResultMap[filename] = fileContents;
-  }));
+  });
   return multifileResultMap;
 }


### PR DESCRIPTION
## feat: support multi-file exports for qt

Fixes: https://github.com/googleapis/google-cloudevents/issues/83 – needed for Java

- Supports multi-file type exports (every language runs through the more generic `quicktypeMultiFile` function now)
- Preserves single file type exports.
- Slightly improves comments
- Slightly improves output

I don't think many languages require this (only `java` and `objective-c` from what I can tell).

### Examples

Java:

```sh
qt \
--in=~/Documents/google-cloudevents/jsonschema/google/events/ \
--out=~/Documents/trash/testqt \
--l=java
***********************
** Quicktype Wrapper **
***********************
* Valid Languages (L): csharp,java,python,rust,crystal,ruby,golang,cplusplus,elm,swift,objective-c,typescript,javascript,kotlin,dart,pike,haskell
***********************
* Config:
- IN=~/Documents/google-cloudevents/jsonschema/google/events/ \
- OUT=~/Documents/trash/testqt \
- L=JAVA
***********************

== START ==
- Finding all JSON Schemas (*.json)...
Found 2 schema(s):
- cloud/audit/v1/LogEntryData.json
- cloud/pubsub/v1/MessagePublishedData.json

## Generating files for MessagePublishedData...
- Converter.java                          : cloud/pubsub/v1/Converter.java
- MessagePublishedData.java               : cloud/pubsub/v1/MessagePublishedData.java
- PubsubMessage.java                      : cloud/pubsub/v1/PubsubMessage.java
## Generating files for LogEntryData...
- Converter.java                          : cloud/audit/v1/Converter.java
- LogEntryData.java                       : cloud/audit/v1/LogEntryData.java
- LogEntryOperation.java                  : cloud/audit/v1/LogEntryOperation.java
- AuditLog.java                           : cloud/audit/v1/AuditLog.java
- AuthenticationInfo.java                 : cloud/audit/v1/AuthenticationInfo.java
- ServiceAccountDelegationInfo.java       : cloud/audit/v1/ServiceAccountDelegationInfo.java
- AuthorizationInfo.java                  : cloud/audit/v1/AuthorizationInfo.java
- Resource.java                           : cloud/audit/v1/Resource.java
- RequestMetadata.java                    : cloud/audit/v1/RequestMetadata.java
- Peer.java                               : cloud/audit/v1/Peer.java
- Request.java                            : cloud/audit/v1/Request.java
- Auth.java                               : cloud/audit/v1/Auth.java
- ResourceLocation.java                   : cloud/audit/v1/ResourceLocation.java
- Status.java                             : cloud/audit/v1/Status.java
- MonitoredResource.java                  : cloud/audit/v1/MonitoredResource.java
== END ==
```

Ruby:

```sh
qt \
--in=~/Documents/google-cloudevents/jsonschema/google/events/ \
--out=~/Documents/trash/testqt \
--l=ruby
***********************
** Quicktype Wrapper **
***********************
* Valid Languages (L): csharp,java,python,rust,crystal,ruby,golang,cplusplus,elm,swift,objective-c,typescript,javascript,kotlin,dart,pike,haskell
***********************
* Config:
- IN=~/Documents/google-cloudevents/jsonschema/google/events/ \
- OUT=~/Documents/trash/testqt \
- L=RUBY
***********************

== START ==
- Finding all JSON Schemas (*.json)...
Found 2 schema(s):
- cloud/audit/v1/LogEntryData.json
- cloud/pubsub/v1/MessagePublishedData.json

## Generating files for MessagePublishedData...
- MessagePublishedData.rb                 : cloud/pubsub/v1/stdout/MessagePublishedData.rb
## Generating files for LogEntryData...
- LogEntryData.rb                         : cloud/audit/v1/stdout/LogEntryData.rb
== END ==
```

