### PR TITLE
feat: qt enable headers flag

### DIFF
--- a/tools/quicktype-wrapper/README.md
+++ b/tools/quicktype-wrapper/README.md
@@ -29,11 +29,16 @@ npm run start
 
 To configure the script, use _environment variables_ or _command-line flags_:
 
+- (REQUIRED) `IN`: Input directory path
+- (REQUIRED) `OUT`: Output directory path
+- (NOT REQUIRED) `NO_LICENSE`: Adds a license header to source files
+
 ### Environment Variables
 
 ```sh
 IN=~/Documents/github/googleapis/google-cloudevents/proto
 OUT=~/Documents/out
+NO_LICENSE=true # optional
 L=typescript
 
 qt
@@ -45,6 +50,7 @@ qt
 qt \
 --in=~/Documents/github/googleapis/google-cloudevents/proto \
 --out=~/Documents/out \
+--no-license=true \ # optional
 --l=typescript
 ```
 

--- a/tools/quicktype-wrapper/README.md
+++ b/tools/quicktype-wrapper/README.md
@@ -29,9 +29,9 @@ npm run start
 
 To configure the script, use _environment variables_ or _command-line flags_:
 
-- (REQUIRED) `IN`: Input directory path
-- (REQUIRED) `OUT`: Output directory path
-- (NOT REQUIRED) `NO_LICENSE`: Adds a license header to source files
+- (REQUIRED) `IN`: Input directory path.
+- (REQUIRED) `OUT`: Output directory path.
+- (NOT REQUIRED) `NO_LICENSE`: Set to `true` to skip adding license headers to source files.
 
 ### Environment Variables
 

--- a/tools/quicktype-wrapper/src/license.ts
+++ b/tools/quicktype-wrapper/src/license.ts
@@ -1,0 +1,30 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const YEAR = (new Date).getFullYear();
+export const HEADER = `// Copyright ${YEAR} Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+`;
+// Note, newline is important here.

--- a/tools/quicktype-wrapper/src/quickstype.ts
+++ b/tools/quicktype-wrapper/src/quickstype.ts
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import {
   InputData,
   quicktypeMultiFile,


### PR DESCRIPTION
Per request, adds option to add license headers to generated files.

Fixes: https://github.com/googleapis/google-cloudevents/issues/88