### PR TITLE
fix: update qt single-out filename

### DIFF
--- a/tools/quicktype-wrapper/src/index.ts
+++ b/tools/quicktype-wrapper/src/index.ts
@@ -123,6 +123,7 @@ if (!module.parent) {
     console.log();
 
     // Loop through every path
+    console.log(`Generating ${L} files:`);
     const pathPromises = absPaths.map(async (f: string, i: number) => {
       const file = readFileSync(f) + '';
       const pathToSchema = relPaths[i]; // e.g. /google/events/cloud/pubsub/MessagePublishedData.json
@@ -137,9 +138,7 @@ if (!module.parent) {
 
       // For each type file...
       // Keep a stdout buffer per type to not intertwine output
-      const bufferedOutput: string[] = [
-        `## Generating files for ${typeName}...`,
-      ];
+      const bufferedOutput: string[] = [];
       for (const [filename, genFileContents] of Object.entries(genFiles)) {
         let fileContentsMaybeWithLicenseHeader = genFileContents;
         // Optionally add license headers
@@ -156,7 +155,7 @@ if (!module.parent) {
         // This next if statement handles if Quicktype generated one or many files
         if (filename === 'stdout') {
           // For languages that just produce one file, Quicktype output filename is 'stdout'.
-          const relativeFilePath = `${relativePathTargetDirectory}/${filename}`;
+          const relativeFilePath = relativePathTargetDirectory;
           const absFilePathDir = `${OUT}/${relativePathTargetDirectory}`;
 
           // Create dir


### PR DESCRIPTION
- Fixes the qt path output for single-file outputs. The current output has "stdout" in the path, which isn't what we want.
- Makes the output a bit more pretty

Tested with Node and Go:

```
***********************
** Quicktype Wrapper **
***********************
* Valid Languages (L): csharp,java,python,rust,crystal,ruby,golang,cplusplus,elm,swift,objective-c,typescript,javascript,kotlin,dart,pike,haskell
***********************
* Config:
- IN=/Users/timmerman/Documents/github/googleapis/google-cloudevents/jsonschema
- OUT=/Users/timmerman/Documents/github/googleapis/google-cloudevents-go
- L=GOLANG
***********************

== START ==
- Finding all JSON Schemas (*.json)...
Found 10 schema(s):
- /google/events/cloud/audit/v1/LogEntryData.json
- /google/events/cloud/pubsub/v1/MessagePublishedData.json
- /google/events/cloud/firestore/v1/DocumentEventData.json
- /google/events/cloud/storage/v1/StorageObjectData.json
- /google/events/cloud/scheduler/v1/SchedulerJobData.json
- /google/events/cloud/cloudbuild/v1/BuildEventData.json
- /google/events/firebase/analytics/v1/AnalyticsLogData.json
- /google/events/firebase/auth/v1/AuthEventData.json
- /google/events/firebase/database/v1/ReferenceEventData.json
- /google/events/firebase/remoteconfig/v1/RemoteConfigEventData.json

Generating GOLANG files:
- SchedulerJobData.go                     : /google/events/cloud/scheduler/v1/SchedulerJobData.go
- RemoteConfigEventData.go                : /google/events/firebase/remoteconfig/v1/RemoteConfigEventData.go
- AuthEventData.go                        : /google/events/firebase/auth/v1/AuthEventData.go
- MessagePublishedData.go                 : /google/events/cloud/pubsub/v1/MessagePublishedData.go
- StorageObjectData.go                    : /google/events/cloud/storage/v1/StorageObjectData.go
- ReferenceEventData.go                   : /google/events/firebase/database/v1/ReferenceEventData.go
- DocumentEventData.go                    : /google/events/cloud/firestore/v1/DocumentEventData.go
- AnalyticsLogData.go                     : /google/events/firebase/analytics/v1/AnalyticsLogData.go
- LogEntryData.go                         : /google/events/cloud/audit/v1/LogEntryData.go
- BuildEventData.go                       : /google/events/cloud/cloudbuild/v1/BuildEventData.go
== END ==
```