### PR TITLE
fix: use dynamic license header characters per language

### DIFF
--- a/tools/quicktype-wrapper/package-lock.json
+++ b/tools/quicktype-wrapper/package-lock.json
@@ -2064,9 +2064,9 @@
       "dev": true
     },
     "quicktype-core": {
-      "version": "6.0.68",
-      "resolved": "https://registry.npmjs.org/quicktype-core/-/quicktype-core-6.0.68.tgz",
-      "integrity": "sha512-9or+dslvADdgXGVYMjGr1xehVvBYr0WLRSgQ7MjaQ+NmAvqSCub9Hsq9S2Bbqj5cyDkm2faulbH4yQ7ksckffw==",
+      "version": "6.0.69",
+      "resolved": "https://registry.npmjs.org/quicktype-core/-/quicktype-core-6.0.69.tgz",
+      "integrity": "sha512-wKQ+/fwgdtFOcbeRiZkIBLA2ajvrFvmtTmexdv7PlO1dyp3C7Irbn2/HjwzalD1dYFrtMEYWohB/4rr3Mg75Xw==",
       "requires": {
         "@mark.probst/unicode-properties": "~1.1.0",
         "browser-or-node": "^1.2.1",
@@ -2821,9 +2821,9 @@
       "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow=="
     },
     "whatwg-fetch": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.4.0.tgz",
-      "integrity": "sha512-rsum2ulz2iuZH08mJkT0Yi6JnKhwdw4oeyMjokgxd+mmqYSd9cPpOQf01TIWgjxG/U4+QR+AwKq6lSbXVxkyoQ=="
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.4.1.tgz",
+      "integrity": "sha512-sofZVzE1wKwO+EYPbWfiwzaKovWiZXf4coEzjGP9b2GBVgQRLQUZ2QcuPpQExGDAW5GItpEm6Tl4OU5mywnAoQ=="
     },
     "which": {
       "version": "1.3.1",

--- a/tools/quicktype-wrapper/src/index.ts
+++ b/tools/quicktype-wrapper/src/index.ts
@@ -15,12 +15,12 @@
 // limitations under the License.
 
 import {readFileSync, writeFileSync} from 'fs';
-import {HEADER} from './license';
 import {
   jsonschema2languageFiles,
   LANGUAGE,
   LANGUAGE_EXT,
   TARGET_LANGUAGE,
+  LANGUAGE_LICENSE_HEADER,
   QtMultifileResult,
 } from './quickstype';
 const {argv} = require('yargs');
@@ -144,7 +144,7 @@ if (!module.parent) {
         let fileContentsMaybeWithLicenseHeader = genFileContents;
         // Optionally add license headers
         if (!NO_LICENSE) {
-          fileContentsMaybeWithLicenseHeader = `${HEADER}\n${fileContentsMaybeWithLicenseHeader}`;
+          fileContentsMaybeWithLicenseHeader = `${LANGUAGE_LICENSE_HEADER[L]}\n${fileContentsMaybeWithLicenseHeader}`;
         }
 
         // Find the relative path

--- a/tools/quicktype-wrapper/src/license.ts
+++ b/tools/quicktype-wrapper/src/license.ts
@@ -13,18 +13,33 @@
 // limitations under the License.
 
 const YEAR = (new Date).getFullYear();
-export const HEADER = `// Copyright ${YEAR} Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+
+/**
+ * Gets the Apache License header with a custom character prefix.
+ * Used to create headers with different comment characters.
+ * @param {string} C The character prefix before the license.
+ */
+const HEADER = (C: string) =>
+`${C} Copyright ${YEAR} Google LLC
+${C}
+${C} Licensed under the Apache License, Version 2.0 (the "License");
+${C} you may not use this file except in compliance with the License.
+${C} You may obtain a copy of the License at
+${C}
+${C}     http://www.apache.org/licenses/LICENSE-2.0
+${C}
+${C} Unless required by applicable law or agreed to in writing, software
+${C} distributed under the License is distributed on an "AS IS" BASIS,
+${C} WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+${C} See the License for the specific language governing permissions and
+${C} limitations under the License.`;
+
+export const HASH_HEADER = HEADER('#') + "\n";
+export const SINGLE_LINE_HEADER = HEADER('//') + "\n";
+export const DASH_LINE_HEADER = HEADER('--') + "\n";
+export const MULTI_LINE_HEADER =
+`/**
+${HEADER(' *')}
+ */
 `;
 // Note, newline is important here.

--- a/tools/quicktype-wrapper/src/quickstype.ts
+++ b/tools/quicktype-wrapper/src/quickstype.ts
@@ -19,6 +19,7 @@ import {
   SerializedRenderResult,
   FetchingJSONSchemaStore,
 } from 'quicktype-core';
+import {HASH_HEADER, DASH_LINE_HEADER, MULTI_LINE_HEADER, SINGLE_LINE_HEADER} from './license';
 // Interface not exported in top-level 'quicktype-core': https://github.com/quicktype/quicktype/pull/1565
 import {MultiFileRenderResult} from '../node_modules/quicktype-core/dist/TargetLanguage';
 
@@ -64,6 +65,26 @@ export const LANGUAGE_EXT = {
   DART: 'dart',
   PIKE: 'pike',
   HASKELL: 'hs',
+};
+// Expected license reference: https://github.com/google/addlicense/tree/master/testdata/expected
+export const LANGUAGE_LICENSE_HEADER = {
+  CSHARP: SINGLE_LINE_HEADER,
+  JAVA: MULTI_LINE_HEADER,
+  PYTHON: HASH_HEADER,
+  RUST: SINGLE_LINE_HEADER,
+  CRYSTAL: HASH_HEADER,
+  RUBY: HASH_HEADER,
+  GOLANG: SINGLE_LINE_HEADER,
+  CPLUSPLUS: SINGLE_LINE_HEADER,
+  ELM: DASH_LINE_HEADER,
+  SWIFT: SINGLE_LINE_HEADER,
+  OBJECTIVEC: SINGLE_LINE_HEADER,
+  TYPESCRIPT: MULTI_LINE_HEADER,
+  JAVASCRIPT: MULTI_LINE_HEADER,
+  KOTLIN: MULTI_LINE_HEADER,
+  DART: SINGLE_LINE_HEADER,
+  PIKE: SINGLE_LINE_HEADER,
+  HASKELL: DASH_LINE_HEADER,
 };
 
 /**


### PR DESCRIPTION
## fix: use dynamic license header characters per language

- Uses the common license header with the correct 
  - Some languages do not support `//` comments
  - Based on https://github.com/google/addlicense/tree/master/testdata/expected with additional languages added.

---

Yoshi Java warns if single-line comments are used for the header:
- https://github.com/googleapis/google-cloudevents-java/issues/24