### PR TITLE
Update renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,6 @@
     "config:base"
   ],
   "schedule": [
-    "monthly"
+    "every 6 months"
   ]
 }


### PR DESCRIPTION
Decreases renovate frequency for internal tools to decrease PR count.

Every 2 years would be fine as well. These dependencies should not change.