### PR TITLE
docs: add cloudevent product name column

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,18 +22,18 @@ may change. Even the core `cloud_event_type` annotation may change.
 
 This repository contains definitions for the following CloudEvents:
 
-|Package|Event types|Data messages|
-|-|-|-|
-|[google.events.cloud.audit.v1](proto/google/events/cloud/audit/v1)|google.cloud.audit.log.v1.written|LogEntryData|
-|[google.events.cloud.cloudbuild.v1](proto/google/events/cloud/cloudbuild/v1)|google.cloud.cloudbuild.build.v1.statusChanged|BuildEventData|
-|[google.events.cloud.firestore.v1](proto/google/events/cloud/firestore/v1)|google.cloud.firestore.document.v1.created<br/>google.cloud.firestore.document.v1.deleted<br/>google.cloud.firestore.document.v1.updated<br/>google.cloud.firestore.document.v1.written|DocumentEventData|
-|[google.events.cloud.pubsub.v1](proto/google/events/cloud/pubsub/v1)|google.cloud.pubsub.topic.v1.messagePublished|MessagePublishedData|
-|[google.events.cloud.scheduler.v1](proto/google/events/cloud/scheduler/v1)|google.cloud.scheduler.job.v1.executed|SchedulerJobData|
-|[google.events.cloud.storage.v1](proto/google/events/cloud/storage/v1)|google.cloud.storage.object.v1.archived<br/>google.cloud.storage.object.v1.deleted<br/>google.cloud.storage.object.v1.finalized<br/>google.cloud.storage.object.v1.metadataUpdated|StorageObjectData|
-|[google.events.firebase.analytics.v1](proto/google/events/firebase/analytics/v1)|google.firebase.analytics.log.v1.written|AnalyticsLogData|
-|[google.events.firebase.auth.v1](proto/google/events/firebase/auth/v1)|google.firebase.auth.user.v1.created<br/>google.firebase.auth.user.v1.deleted|AuthEventData|
-|[google.events.firebase.database.v1](proto/google/events/firebase/database/v1)|google.firebase.database.ref.v1.created<br/>google.firebase.database.ref.v1.deleted<br/>google.firebase.database.ref.v1.updated<br/>google.firebase.database.ref.v1.written|ReferenceEventData|
-|[google.events.firebase.remoteconfig.v1](proto/google/events/firebase/remoteconfig/v1)|google.firebase.remoteconfig.remoteConfig.v1.updated|RemoteConfigEventData|
+|Product|Package|Event types|Data messages|
+|-|-|-|-|
+|Cloud Audit Logs|[google.events.cloud.audit.v1](proto/google/events/cloud/audit/v1)|google.cloud.audit.log.v1.written|LogEntryData|
+|Cloud Build|[google.events.cloud.cloudbuild.v1](proto/google/events/cloud/cloudbuild/v1)|google.cloud.cloudbuild.build.v1.statusChanged|BuildEventData|
+|Cloud Firestore|[google.events.cloud.firestore.v1](proto/google/events/cloud/firestore/v1)|google.cloud.firestore.document.v1.created<br/>google.cloud.firestore.document.v1.deleted<br/>google.cloud.firestore.document.v1.updated<br/>google.cloud.firestore.document.v1.written|DocumentEventData|
+|Cloud Pub/Sub|[google.events.cloud.pubsub.v1](proto/google/events/cloud/pubsub/v1)|google.cloud.pubsub.topic.v1.messagePublished|MessagePublishedData|
+|Cloud Scheduler|[google.events.cloud.scheduler.v1](proto/google/events/cloud/scheduler/v1)|google.cloud.scheduler.job.v1.executed|SchedulerJobData|
+|Cloud Storage|[google.events.cloud.storage.v1](proto/google/events/cloud/storage/v1)|google.cloud.storage.object.v1.archived<br/>google.cloud.storage.object.v1.deleted<br/>google.cloud.storage.object.v1.finalized<br/>google.cloud.storage.object.v1.metadataUpdated|StorageObjectData|
+|Google Analytics for Firebase|[google.events.firebase.analytics.v1](proto/google/events/firebase/analytics/v1)|google.firebase.analytics.log.v1.written|AnalyticsLogData|
+|Firebase Authentication|[google.events.firebase.auth.v1](proto/google/events/firebase/auth/v1)|google.firebase.auth.user.v1.created<br/>google.firebase.auth.user.v1.deleted|AuthEventData|
+|Firebase Realtime Database|[google.events.firebase.database.v1](proto/google/events/firebase/database/v1)|google.firebase.database.ref.v1.created<br/>google.firebase.database.ref.v1.deleted<br/>google.firebase.database.ref.v1.updated<br/>google.firebase.database.ref.v1.written|ReferenceEventData|
+|Firebase Remote Config|[google.events.firebase.remoteconfig.v1](proto/google/events/firebase/remoteconfig/v1)|google.firebase.remoteconfig.remoteConfig.v1.updated|RemoteConfigEventData|
 
 ## CloudEvent Type Repos
 

--- a/tools/registry/Google.Events.Tools.GenerateRegistry/Program.cs
+++ b/tools/registry/Google.Events.Tools.GenerateRegistry/Program.cs
@@ -38,7 +38,7 @@ namespace Google.Events.Tools.GenerateRegistry
         /// The Markdown header for the table at the start of the event registry. This string is used
         /// to find the table within the README.
         /// </summary>
-        private const string TableHeader = "|Package|Event types|Data messages|";
+        private const string TableHeader = "|Product|Package|Event types|Data messages|";
 
         /// <summary>
         /// The line between the table header and the table content. This is the same number of | characters
@@ -159,6 +159,39 @@ namespace Google.Events.Tools.GenerateRegistry
     class TableRow
     {
         /// <summary>
+        /// The product represented in this row.
+        /// </summary>
+        public string Product {
+            get {
+                switch (Package)
+                {
+                    case "google.events.cloud.audit.v1":
+                        return "Cloud Audit Logs";
+                    case "google.events.cloud.cloudbuild.v1":
+                        return "Cloud Build";
+                    case "google.events.cloud.firestore.v1":
+                        return "Cloud Firestore";
+                    case "google.events.cloud.pubsub.v1":
+                        return "Cloud Pub/Sub";
+                    case "google.events.cloud.scheduler.v1":
+                        return "Cloud Scheduler";
+                    case "google.events.cloud.storage.v1":
+                        return "Cloud Storage";
+                    case "google.events.firebase.analytics.v1":
+                        return "Google Analytics for Firebase";
+                    case "google.events.firebase.auth.v1":
+                        return "Firebase Authentication";
+                    case "google.events.firebase.database.v1":
+                        return "Firebase Realtime Database";
+                    case "google.events.firebase.remoteconfig.v1":
+                        return "Firebase Remote Config";
+                    default:
+                        throw new ArgumentException("Unknown product. Please add corresponding product name.");
+                }
+            }
+        }
+
+        /// <summary>
         /// The protobuf package represented in this row.
         /// </summary>
         public string Package { get; }
@@ -183,17 +216,20 @@ namespace Google.Events.Tools.GenerateRegistry
         /// </summary>
         public string ToMarkdown()
         {
-            // The first column is the package name, with a link to the directory containing the protos.
+            // Product name / API name
+            var productColumn = Product;
+
+            // Package name with a link to the directory containing the protos.
             var packageColumn = $"[{Package}](proto/{string.Join("/", Package.Split('.'))})";
 
-            // The second column is the event types, in lexicographic order, separated by HTML line breaks.
+            // Event types in lexicographic order, separated by HTML line breaks.
             var eventTypesColumn = string.Join("<br/>", EventTypes.OrderBy(type => type, StringComparer.Ordinal));
 
-            // The third column is the data messages, in lexicographic order, separated by HTML line breaks.
+            // Data messages, in lexicographic order, separated by HTML line breaks.
             var dataMessagesColumn = string.Join("<br/>", DataMessages.OrderBy(type => type, StringComparer.Ordinal));
 
             // Join the columns together, using | as the delimiter.
-            return $"|{packageColumn}|{eventTypesColumn}|{dataMessagesColumn}|";
+            return $"|{productColumn}|{packageColumn}|{eventTypesColumn}|{dataMessagesColumn}|";
         }
     }
 }


### PR DESCRIPTION
Fixes #67

- Adds Product name column
  - These human-readable product name are not structurally defined in protos
  - Exact spelling pulled from product pages
- README table generator throws exception when trying to gen with an unknown package
- Updates comments around column numbers. The ordering of columns is not imperative and can be changed.