### PR TITLE
feat: init jsonschema catalog

### DIFF
--- a/jsonschema/catalog.json
+++ b/jsonschema/catalog.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json.schemastore.org/schema-catalog",
+  "version": 1,
+  "schemas": [
+    {
+      "url": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/cloud/audit/v1/LogEntryData.json",
+      "name": "LogEntryData",
+      "description": "Generic log entry, used as a wrapper for Cloud Audit Logs in events.\n This is copied from\n https://github.com/googleapis/googleapis/blob/master/google/logging/v2/log_entry.proto\n and adapted appropriately."
+    },
+    {
+      "url": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/cloud/pubsub/v1/MessagePublishedData.json",
+      "name": "MessagePublishedData",
+      "description": "The data received in an event when a message is published to a topic."
+    },
+    {
+      "url": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/cloud/firestore/v1/DocumentEventData.json",
+      "name": "DocumentEventData",
+      "description": "The data within all Firestore document events."
+    },
+    {
+      "url": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/cloud/cloudbuild/v1/BuildEventData.json",
+      "name": "BuildEventData",
+      "description": "Build event data\n Common build format for Google Cloud Platform API operations.\n Copied from\n https://github.com/googleapis/googleapis/blob/master/google/devtools/cloudbuild/v1/cloudbuild.proto."
+    },
+    {
+      "url": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/cloud/storage/v1/StorageObjectData.json",
+      "name": "StorageObjectData",
+      "description": "An object within Google Cloud Storage."
+    },
+    {
+      "url": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/cloud/scheduler/v1/SchedulerJobData.json",
+      "name": "SchedulerJobData",
+      "description": "Scheduler job data."
+    },
+    {
+      "url": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/firebase/analytics/v1/AnalyticsLogData.json",
+      "name": "AnalyticsLogData",
+      "description": "The data within Firebase Analytics log events."
+    },
+    {
+      "url": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/firebase/database/v1/ReferenceEventData.json",
+      "name": "ReferenceEventData",
+      "description": "The data within all Firebase Real Time Database reference events."
+    },
+    {
+      "url": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/firebase/auth/v1/AuthEventData.json",
+      "name": "AuthEventData",
+      "description": "The data within all Firebase Auth events"
+    },
+    {
+      "url": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/firebase/remoteconfig/v1/RemoteConfigEventData.json",
+      "name": "RemoteConfigEventData",
+      "description": "The data within all Firebase Remote Config events."
+    }
+  ]
+}

--- a/jsonschema/catalog.json
+++ b/jsonschema/catalog.json
@@ -3,53 +3,63 @@
   "version": 1,
   "schemas": [
     {
-      "url": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/cloud/audit/v1/LogEntryData.json",
-      "name": "LogEntryData",
-      "description": "Generic log entry, used as a wrapper for Cloud Audit Logs in events.\n This is copied from\n https://github.com/googleapis/googleapis/blob/master/google/logging/v2/log_entry.proto\n and adapted appropriately."
+      "url": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/cloud/cloudbuild/v1/BuildEventData.json",
+      "name": "BuildEventData",
+      "cloudevent": "google.events.cloud.cloudbuild.v1",
+      "description": "Build event data\n Common build format for Google Cloud Platform API operations.\n Copied from\n https://github.com/googleapis/googleapis/blob/master/google/devtools/cloudbuild/v1/cloudbuild.proto."
+    },
+    {
+      "url": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/cloud/scheduler/v1/SchedulerJobData.json",
+      "name": "SchedulerJobData",
+      "cloudevent": "google.events.cloud.scheduler.v1",
+      "description": "Scheduler job data."
     },
     {
       "url": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/cloud/pubsub/v1/MessagePublishedData.json",
       "name": "MessagePublishedData",
+      "cloudevent": "google.events.cloud.pubsub.v1",
       "description": "The data received in an event when a message is published to a topic."
     },
     {
       "url": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/cloud/firestore/v1/DocumentEventData.json",
       "name": "DocumentEventData",
+      "cloudevent": "google.events.cloud.firestore.v1",
       "description": "The data within all Firestore document events."
     },
     {
-      "url": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/cloud/cloudbuild/v1/BuildEventData.json",
-      "name": "BuildEventData",
-      "description": "Build event data\n Common build format for Google Cloud Platform API operations.\n Copied from\n https://github.com/googleapis/googleapis/blob/master/google/devtools/cloudbuild/v1/cloudbuild.proto."
+      "url": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/cloud/audit/v1/LogEntryData.json",
+      "name": "LogEntryData",
+      "cloudevent": "google.events.cloud.audit.v1",
+      "description": "Generic log entry, used as a wrapper for Cloud Audit Logs in events.\n This is copied from\n https://github.com/googleapis/googleapis/blob/master/google/logging/v2/log_entry.proto\n and adapted appropriately."
     },
     {
       "url": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/cloud/storage/v1/StorageObjectData.json",
       "name": "StorageObjectData",
+      "cloudevent": "google.events.cloud.storage.v1",
       "description": "An object within Google Cloud Storage."
-    },
-    {
-      "url": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/cloud/scheduler/v1/SchedulerJobData.json",
-      "name": "SchedulerJobData",
-      "description": "Scheduler job data."
     },
     {
       "url": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/firebase/analytics/v1/AnalyticsLogData.json",
       "name": "AnalyticsLogData",
+      "cloudevent": "google.events.firebase.analytics.v1",
       "description": "The data within Firebase Analytics log events."
-    },
-    {
-      "url": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/firebase/database/v1/ReferenceEventData.json",
-      "name": "ReferenceEventData",
-      "description": "The data within all Firebase Real Time Database reference events."
     },
     {
       "url": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/firebase/auth/v1/AuthEventData.json",
       "name": "AuthEventData",
+      "cloudevent": "google.events.firebase.auth.v1",
       "description": "The data within all Firebase Auth events"
+    },
+    {
+      "url": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/firebase/database/v1/ReferenceEventData.json",
+      "name": "ReferenceEventData",
+      "cloudevent": "google.events.firebase.database.v1",
+      "description": "The data within all Firebase Real Time Database reference events."
     },
     {
       "url": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/firebase/remoteconfig/v1/RemoteConfigEventData.json",
       "name": "RemoteConfigEventData",
+      "cloudevent": "google.events.firebase.remoteconfig.v1",
       "description": "The data within all Firebase Remote Config events."
     }
   ]

--- a/jsonschema/catalog.json
+++ b/jsonschema/catalog.json
@@ -3,64 +3,104 @@
   "version": 1,
   "schemas": [
     {
-      "url": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/cloud/cloudbuild/v1/BuildEventData.json",
-      "name": "BuildEventData",
-      "cloudevent": "google.events.cloud.cloudbuild.v1",
-      "description": "Build event data\n Common build format for Google Cloud Platform API operations.\n Copied from\n https://github.com/googleapis/googleapis/blob/master/google/devtools/cloudbuild/v1/cloudbuild.proto."
-    },
-    {
-      "url": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/cloud/scheduler/v1/SchedulerJobData.json",
-      "name": "SchedulerJobData",
-      "cloudevent": "google.events.cloud.scheduler.v1",
-      "description": "Scheduler job data."
-    },
-    {
       "url": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/cloud/pubsub/v1/MessagePublishedData.json",
       "name": "MessagePublishedData",
-      "cloudevent": "google.events.cloud.pubsub.v1",
-      "description": "The data received in an event when a message is published to a topic."
-    },
-    {
-      "url": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/cloud/firestore/v1/DocumentEventData.json",
-      "name": "DocumentEventData",
-      "cloudevent": "google.events.cloud.firestore.v1",
-      "description": "The data within all Firestore document events."
+      "description": "The data received in an event when a message is published to a topic.",
+      "datatype": "google.events.cloud.pubsub.v1.MessagePublishedData",
+      "cloudeventTypes": [
+        "google.cloud.pubsub.topic.v1.messagePublished"
+      ]
     },
     {
       "url": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/cloud/audit/v1/LogEntryData.json",
       "name": "LogEntryData",
-      "cloudevent": "google.events.cloud.audit.v1",
-      "description": "Generic log entry, used as a wrapper for Cloud Audit Logs in events.\n This is copied from\n https://github.com/googleapis/googleapis/blob/master/google/logging/v2/log_entry.proto\n and adapted appropriately."
+      "description": "Generic log entry, used as a wrapper for Cloud Audit Logs in events.\n This is copied from\n https://github.com/googleapis/googleapis/blob/master/google/logging/v2/log_entry.proto\n and adapted appropriately.",
+      "datatype": "google.events.cloud.audit.v1.LogEntryData",
+      "cloudeventTypes": [
+        "google.cloud.audit.log.v1.written"
+      ]
+    },
+    {
+      "url": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/cloud/cloudbuild/v1/BuildEventData.json",
+      "name": "BuildEventData",
+      "description": "Build event data\n Common build format for Google Cloud Platform API operations.\n Copied from\n https://github.com/googleapis/googleapis/blob/master/google/devtools/cloudbuild/v1/cloudbuild.proto.",
+      "datatype": "google.events.cloud.cloudbuild.v1.BuildEventData",
+      "cloudeventTypes": [
+        "google.cloud.cloudbuild.build.v1.statusChanged"
+      ]
+    },
+    {
+      "url": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/cloud/scheduler/v1/SchedulerJobData.json",
+      "name": "SchedulerJobData",
+      "description": "Scheduler job data.",
+      "datatype": "google.events.cloud.scheduler.v1.SchedulerJobData",
+      "cloudeventTypes": [
+        "google.cloud.scheduler.job.v1.executed"
+      ]
     },
     {
       "url": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/cloud/storage/v1/StorageObjectData.json",
       "name": "StorageObjectData",
-      "cloudevent": "google.events.cloud.storage.v1",
-      "description": "An object within Google Cloud Storage."
+      "description": "An object within Google Cloud Storage.",
+      "datatype": "google.events.cloud.storage.v1.StorageObjectData",
+      "cloudeventTypes": [
+        "google.cloud.storage.object.v1.finalized",
+        "google.cloud.storage.object.v1.archived",
+        "google.cloud.storage.object.v1.deleted",
+        "google.cloud.storage.object.v1.metadataUpdated"
+      ]
     },
     {
-      "url": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/firebase/analytics/v1/AnalyticsLogData.json",
-      "name": "AnalyticsLogData",
-      "cloudevent": "google.events.firebase.analytics.v1",
-      "description": "The data within Firebase Analytics log events."
-    },
-    {
-      "url": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/firebase/auth/v1/AuthEventData.json",
-      "name": "AuthEventData",
-      "cloudevent": "google.events.firebase.auth.v1",
-      "description": "The data within all Firebase Auth events"
+      "url": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/cloud/firestore/v1/DocumentEventData.json",
+      "name": "DocumentEventData",
+      "description": "The data within all Firestore document events.",
+      "datatype": "google.events.cloud.firestore.v1.DocumentEventData",
+      "cloudeventTypes": [
+        "google.cloud.firestore.document.v1.created",
+        "google.cloud.firestore.document.v1.updated",
+        "google.cloud.firestore.document.v1.deleted",
+        "google.cloud.firestore.document.v1.written"
+      ]
     },
     {
       "url": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/firebase/database/v1/ReferenceEventData.json",
       "name": "ReferenceEventData",
-      "cloudevent": "google.events.firebase.database.v1",
-      "description": "The data within all Firebase Real Time Database reference events."
+      "description": "The data within all Firebase Real Time Database reference events.",
+      "datatype": "google.events.firebase.database.v1.ReferenceEventData",
+      "cloudeventTypes": [
+        "google.firebase.database.ref.v1.created",
+        "google.firebase.database.ref.v1.updated",
+        "google.firebase.database.ref.v1.deleted",
+        "google.firebase.database.ref.v1.written"
+      ]
+    },
+    {
+      "url": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/firebase/auth/v1/AuthEventData.json",
+      "name": "AuthEventData",
+      "description": "The data within all Firebase Auth events",
+      "datatype": "google.events.firebase.auth.v1.AuthEventData",
+      "cloudeventTypes": [
+        "google.firebase.auth.user.v1.created",
+        "google.firebase.auth.user.v1.deleted"
+      ]
+    },
+    {
+      "url": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/firebase/analytics/v1/AnalyticsLogData.json",
+      "name": "AnalyticsLogData",
+      "description": "The data within Firebase Analytics log events.",
+      "datatype": "google.events.firebase.analytics.v1.AnalyticsLogData",
+      "cloudeventTypes": [
+        "google.firebase.analytics.log.v1.written"
+      ]
     },
     {
       "url": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/firebase/remoteconfig/v1/RemoteConfigEventData.json",
       "name": "RemoteConfigEventData",
-      "cloudevent": "google.events.firebase.remoteconfig.v1",
-      "description": "The data within all Firebase Remote Config events."
+      "description": "The data within all Firebase Remote Config events.",
+      "datatype": "google.events.firebase.remoteconfig.v1.RemoteConfigEventData",
+      "cloudeventTypes": [
+        "google.firebase.remoteconfig.remoteConfig.v1.updated"
+      ]
     }
   ]
 }

--- a/tools/jsonschema-catalog/.gitignore
+++ b/tools/jsonschema-catalog/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/tools/jsonschema-catalog/README.md
+++ b/tools/jsonschema-catalog/README.md
@@ -1,0 +1,27 @@
+# jsonschema-catalog
+
+This tool generates a catalog for JSON schemas.
+
+## Requirements
+
+This tool requires the following languages:
+
+* `node 10`+
+
+## Install
+
+Install dependencies:
+
+``` sh
+npm i
+```
+
+### Run
+
+Run the JSON schema catalog generator:
+
+``` sh
+npm start
+```
+
+This catalog lives in a file: `jsonschema/catalog.json`

--- a/tools/jsonschema-catalog/index.js
+++ b/tools/jsonschema-catalog/index.js
@@ -12,7 +12,7 @@ console.log(`Iterating through JSON schemas:`);
   const filePaths = await recursive(ROOT);
   
   // For every JSON schema file, besides the catalog, read the file and gather data.
-  const cloudeventJSONSchemas = [];
+  let cloudeventJSONSchemas = [];
   filePaths.map(filePath => {
     if (filePath.includes('catalog.json')) return; // don't include self
     const json = JSON.parse(fs.readFileSync(filePath).toString());
@@ -22,11 +22,13 @@ console.log(`Iterating through JSON schemas:`);
     cloudeventJSONSchemas.push({
       url: json.$id,
       name: json.name,
-      description: json.description,
-      package: json.package,
       datatype: json.datatype,
+      cloudeventTypes: json.cloudeventTypes,
+      description: json.description,
     });
   });
+  // Sort by URL (to prevent random ordering)
+  cloudeventJSONSchemas = cloudeventJSONSchemas.sort((s1, s2) => s1.package < s2.package);
 
   // Create the catalog file that follows the schema-catalog.
   const catalog = {

--- a/tools/jsonschema-catalog/index.js
+++ b/tools/jsonschema-catalog/index.js
@@ -22,9 +22,9 @@ console.log(`Iterating through JSON schemas:`);
     cloudeventJSONSchemas.push({
       url: json.$id,
       name: json.name,
+      description: json.description,
       datatype: json.datatype,
       cloudeventTypes: json.cloudeventTypes,
-      description: json.description,
     });
   });
   // Sort by URL (to prevent random ordering)

--- a/tools/jsonschema-catalog/index.js
+++ b/tools/jsonschema-catalog/index.js
@@ -1,0 +1,39 @@
+const path = require('path');
+const fs = require('fs');
+const recursive = require("recursive-readdir");
+
+/**
+ * Generates the jsonschema catalog file.
+ */
+const ROOT = path.resolve(`${__dirname}/../../jsonschema`);
+console.log(`Iterating through JSON schemas:`);
+
+(async () => {
+  const filePaths = await recursive(ROOT);
+  
+  // For every JSON schema file, besides the catalog, read the file and gather data.
+  const cloudeventJSONSchemas = [];
+  filePaths.map(filePath => {
+    if (filePath.includes('catalog.json')) return; // don't include self
+    const json = JSON.parse(fs.readFileSync(filePath).toString());
+    console.log(`- ${json.$id}`);
+
+    // Add schema catalog entry with specific fields.
+    cloudeventJSONSchemas.push({
+      url: json.$id,
+      name: json.name,
+      description: json.description,
+      package: json.package,
+      datatype: json.datatype,
+    });
+  });
+
+  // Create the catalog file that follows the schema-catalog.
+  const catalog = {
+    $schema: 'https://json.schemastore.org/schema-catalog',
+    version: 1, // required
+    schemas: cloudeventJSONSchemas,
+  };
+  fs.writeFileSync(`${ROOT}/catalog.json`, JSON.stringify(catalog, null, 2));
+  console.log(`Created: ${ROOT}/catalog.json`);
+})();

--- a/tools/jsonschema-catalog/package-lock.json
+++ b/tools/jsonschema-catalog/package-lock.json
@@ -1,0 +1,66 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+    },
+    "camelcase-keys": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+      "requires": {
+        "camelcase": "^5.3.1",
+        "map-obj": "^4.0.0",
+        "quick-lru": "^4.0.1"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "map-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.1.0.tgz",
+      "integrity": "sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g=="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "quick-lru": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g=="
+    },
+    "recursive-readdir": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.2.tgz",
+      "integrity": "sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==",
+      "requires": {
+        "minimatch": "3.0.4"
+      }
+    }
+  }
+}

--- a/tools/jsonschema-catalog/package.json
+++ b/tools/jsonschema-catalog/package.json
@@ -1,0 +1,10 @@
+{
+  "main": "index.js",
+  "scripts": {
+    "start": "node ."
+  },
+  "dependencies": {
+    "camelcase-keys": "^6.2.2",
+    "recursive-readdir": "^2.2.2"
+  }
+}


### PR DESCRIPTION
Adds JSON schema catalog/registry

- Implements part 2 of 2 for design doc "Proposal: CloudEvent JSON Schema Registry".
- Note: Catalog entries will be updated (and a bit more complete) when jsonschema enhancements are in: https://github.com/googleapis/google-cloudevents/pull/112