### PR TITLE
fix: standardize data proto descriptions

### DIFF
--- a/proto/google/events/cloud/audit/v1/data.proto
+++ b/proto/google/events/cloud/audit/v1/data.proto
@@ -24,10 +24,7 @@ import "google/rpc/status.proto";
 
 option csharp_namespace = "Google.Events.Protobuf.Cloud.Audit.V1";
 
-// Generic log entry, used as a wrapper for Cloud Audit Logs in events.
-// This is copied from
-// https://github.com/googleapis/googleapis/blob/master/google/logging/v2/log_entry.proto
-// and adapted appropriately.
+// The data within all Cloud Audit Logs log entry events.
 message LogEntryData {
   // The resource name of the log to which this log entry belongs.
   string log_name = 12;

--- a/proto/google/events/cloud/cloudbuild/v1/data.proto
+++ b/proto/google/events/cloud/cloudbuild/v1/data.proto
@@ -21,10 +21,7 @@ import "google/protobuf/timestamp.proto";
 
 option csharp_namespace = "Google.Events.Protobuf.Cloud.CloudBuild.V1";
 
-// Build event data
-// Common build format for Google Cloud Platform API operations.
-// Copied from
-// https://github.com/googleapis/googleapis/blob/master/google/devtools/cloudbuild/v1/cloudbuild.proto.
+// Build event data for Google Cloud Platform API operations.
 message BuildEventData {
   // Possible status of a build or build step.
   enum Status {

--- a/proto/google/events/cloud/pubsub/v1/data.proto
+++ b/proto/google/events/cloud/pubsub/v1/data.proto
@@ -18,7 +18,7 @@ package google.events.cloud.pubsub.v1;
 
 option csharp_namespace = "Google.Events.Protobuf.Cloud.PubSub.V1";
 
-// The data received in an event when a message is published to a topic.
+// The event data when a message is published to a topic.
 message MessagePublishedData {
   // The message that was published.
   PubsubMessage message = 1;

--- a/proto/google/events/firebase/auth/v1/data.proto
+++ b/proto/google/events/firebase/auth/v1/data.proto
@@ -21,7 +21,7 @@ import "google/protobuf/timestamp.proto";
 
 option csharp_namespace = "Google.Events.Protobuf.Firebase.Auth.V1";
 
-// The data within all Firebase Auth events
+// The data within all Firebase Auth events.
 message AuthEventData {
   // The user identifier in the Firebase app.
   string uid = 1;


### PR DESCRIPTION
Reviews all data.proto descriptions. These descriptions are used in the JSON schemas and client libraries.

Fixes https://github.com/googleapis/google-cloudevents/issues/118