### PR TITLE
fix: remove oneof type for 64 bit numbers

### DIFF
--- a/jsonschema/google/events/cloud/audit/v1/LogEntryData.json
+++ b/jsonschema/google/events/cloud/audit/v1/LogEntryData.json
@@ -88,14 +88,7 @@
           "description": "The resource's original state before mutation. Present only for\n operations which have successfully modified the targeted resource(s).\n In general, this field should contain all changed fields, except those\n that are already been included in `request`, `response`, `metadata` or\n `service_data` fields.\n When the JSON object represented here has a proto equivalent,\n the proto name will be indicated in the `@type` property."
         },
         "numResponseItems": {
-          "oneOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "string"
-            }
-          ],
+          "type": "string",
           "description": "The number of items returned from a List or Query API method,\n if applicable."
         },
         "status": {
@@ -349,14 +342,7 @@
                   "format": "date-time"
                 },
                 "size": {
-                  "oneOf": [
-                    {
-                      "type": "integer"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ],
+                  "type": "string",
                   "description": "The HTTP request size in bytes. If unknown, it must be -1."
                 },
                 "protocol": {
@@ -429,14 +415,7 @@
                   "description": "The IP address of the peer."
                 },
                 "port": {
-                  "oneOf": [
-                    {
-                      "type": "integer"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ],
+                  "type": "string",
                   "description": "The network port of the peer."
                 },
                 "labels": {

--- a/jsonschema/google/events/cloud/cloudbuild/v1/BuildEventData.json
+++ b/jsonschema/google/events/cloud/cloudbuild/v1/BuildEventData.json
@@ -140,14 +140,7 @@
           "timeout": {
             "properties": {
               "seconds": {
-                "oneOf": [
-                  {
-                    "type": "integer"
-                  },
-                  {
-                    "type": "string"
-                  }
-                ],
+                "type": "string",
                 "description": "Signed seconds of the span of time. Must be from -315,576,000,000\n to +315,576,000,000 inclusive. Note: these bounds are computed from:\n 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years"
               },
               "nanos": {
@@ -217,14 +210,7 @@
           "description": "Path to the artifact manifest. Only populated when artifacts are uploaded."
         },
         "numArtifacts": {
-          "oneOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "string"
-            }
-          ],
+          "type": "string",
           "description": "Number of artifacts uploaded. Only populated when artifacts are uploaded."
         },
         "buildStepOutputs": {
@@ -263,14 +249,7 @@
     "timeout": {
       "properties": {
         "seconds": {
-          "oneOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "string"
-            }
-          ],
+          "type": "string",
           "description": "Signed seconds of the span of time. Must be from -315,576,000,000\n to +315,576,000,000 inclusive. Note: these bounds are computed from:\n 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years"
         },
         "nanos": {
@@ -292,14 +271,7 @@
     "queueTtl": {
       "properties": {
         "seconds": {
-          "oneOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "string"
-            }
-          ],
+          "type": "string",
           "description": "Signed seconds of the span of time. Must be from -315,576,000,000\n to +315,576,000,000 inclusive. Note: these bounds are computed from:\n 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years"
         },
         "nanos": {
@@ -473,14 +445,7 @@
           "description": "Compute Engine machine type on which to run the build."
         },
         "diskSizeGb": {
-          "oneOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "string"
-            }
-          ],
+          "type": "string",
           "description": "Requested disk size for the VM that runs the build. Note that this is *NOT*\n \"disk free\"; some of the space will be used by the operating system and\n build utilities. Also note that this is the minimum disk size that will be\n allocated for the build -- the build may run with a larger disk than\n requested. At present, the maximum disk size is 1000GB; builds that request\n more than the maximum are rejected with an error."
         },
         "substitutionOption": {
@@ -676,14 +641,7 @@
           "description": "Google Cloud Storage object containing the source."
         },
         "generation": {
-          "oneOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "string"
-            }
-          ],
+          "type": "string",
           "description": "Google Cloud Storage generation for the object. If the generation is\n omitted, the latest generation will be used."
         }
       },

--- a/jsonschema/google/events/cloud/firestore/v1/DocumentEventData.json
+++ b/jsonschema/google/events/cloud/firestore/v1/DocumentEventData.json
@@ -92,14 +92,7 @@
           "description": "A boolean value."
         },
         "integerValue": {
-          "oneOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "string"
-            }
-          ],
+          "type": "string",
           "description": "An integer value."
         },
         "doubleValue": {

--- a/jsonschema/google/events/cloud/storage/v1/StorageObjectData.json
+++ b/jsonschema/google/events/cloud/storage/v1/StorageObjectData.json
@@ -29,14 +29,7 @@
       "description": "Content-Language of the object data, matching\n [https://tools.ietf.org/html/rfc7231#section-3.1.3.2][RFC 7231 §3.1.3.2]."
     },
     "metageneration": {
-      "oneOf": [
-        {
-          "type": "integer"
-        },
-        {
-          "type": "string"
-        }
-      ],
+      "type": "string",
       "description": "The version of the metadata for this object at this generation. Used for\n preconditions and for detecting changes in metadata. A metageneration\n number is only meaningful in the context of a particular generation of a\n particular object."
     },
     "timeDeleted": {
@@ -49,14 +42,7 @@
       "description": "Content-Type of the object data, matching\n [https://tools.ietf.org/html/rfc7231#section-3.1.1.5][RFC 7231 §3.1.1.5].\n If an object is stored without a Content-Type, it is served as\n `application/octet-stream`."
     },
     "size": {
-      "oneOf": [
-        {
-          "type": "integer"
-        },
-        {
-          "type": "string"
-        }
-      ],
+      "type": "string",
       "description": "Content-Length of the object data in bytes, matching\n [https://tools.ietf.org/html/rfc7230#section-3.3.2][RFC 7230 §3.3.2]."
     },
     "timeCreated": {
@@ -131,14 +117,7 @@
       "description": "The name of the bucket containing this object."
     },
     "generation": {
-      "oneOf": [
-        {
-          "type": "integer"
-        },
-        {
-          "type": "string"
-        }
-      ],
+      "type": "string",
       "description": "The content generation of this object. Used for object versioning.\n Attempting to set this field will result in an error."
     },
     "customerEncryption": {

--- a/jsonschema/google/events/firebase/analytics/v1/AnalyticsLogData.json
+++ b/jsonschema/google/events/firebase/analytics/v1/AnalyticsLogData.json
@@ -16,14 +16,7 @@
           "description": "The user ID set via the setUserId API."
         },
         "firstOpenTimestampMicros": {
-          "oneOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "string"
-            }
-          ],
+          "type": "string",
           "description": "The time (in microseconds) at which the user first opened the app."
         },
         "userProperties": {
@@ -36,14 +29,7 @@
                 "description": "Last set value of user property."
               },
               "setTimestampUsec": {
-                "oneOf": [
-                  {
-                    "type": "integer"
-                  },
-                  {
-                    "type": "string"
-                  }
-                ],
+                "type": "string",
                 "description": "UTC client time when user property was last set."
               },
               "index": {
@@ -184,14 +170,7 @@
               "description": "Monotonically increasing index for each bundle set by SDK."
             },
             "serverTimestampOffsetMicros": {
-              "oneOf": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "string"
-                }
-              ],
+              "type": "string",
               "description": "Timestamp offset between collection time and upload time."
             }
           },
@@ -240,25 +219,11 @@
             "description": "A repeated record of the parameters associated with this event."
           },
           "timestampMicros": {
-            "oneOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "string"
-              }
-            ],
+            "type": "string",
             "description": "UTC client time when the event happened."
           },
           "previousTimestampMicros": {
-            "oneOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "string"
-              }
-            ],
+            "type": "string",
             "description": "UTC client time when the previous event happened."
           },
           "valueInUsd": {
@@ -284,14 +249,7 @@
           "type": "string"
         },
         "intValue": {
-          "oneOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "string"
-            }
-          ]
+          "type": "string"
         },
         "floatValue": {
           "type": "number"

--- a/jsonschema/google/events/firebase/remoteconfig/v1/RemoteConfigEventData.json
+++ b/jsonschema/google/events/firebase/remoteconfig/v1/RemoteConfigEventData.json
@@ -10,14 +10,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {
     "versionNumber": {
-      "oneOf": [
-        {
-          "type": "integer"
-        },
-        {
-          "type": "string"
-        }
-      ],
+      "type": "string",
       "description": "The version number of the version's corresponding Remote Config template."
     },
     "updateTime": {
@@ -71,14 +64,7 @@
       "description": "What type of update was made."
     },
     "rollbackSource": {
-      "oneOf": [
-        {
-          "type": "integer"
-        },
-        {
-          "type": "string"
-        }
-      ],
+      "type": "string",
       "description": "Only present if this version is the result of a rollback, and will be the\n version number of the Remote Config template that was rolled-back to."
     }
   },

--- a/tools/proto2jsonschema/gen.sh
+++ b/tools/proto2jsonschema/gen.sh
@@ -43,7 +43,7 @@ cd ..
 echo "- Setting up protoc plugin (chrusty/protoc-gen-jsonschema)"
 # Pin chrusty tool to specific version: https://github.com/chrusty/protoc-gen-jsonschema/tags
 go get -v github.com/chrusty/protoc-gen-jsonschema/cmd/protoc-gen-jsonschema
-GO111MODULE=on go get -v github.com/chrusty/protoc-gen-jsonschema/cmd/protoc-gen-jsonschema@0.9.5
+GO111MODULE=on go get -v github.com/chrusty/protoc-gen-jsonschema/cmd/protoc-gen-jsonschema@0.9.7
 go install github.com/chrusty/protoc-gen-jsonschema/cmd/protoc-gen-jsonschema
 
 echo "- Converting protos to JSON Schemas"


### PR DESCRIPTION
Uses `type: string` for proto `int64` (and related (`*64`) types per [proto JSON representation spec](https://developers.google.com/protocol-buffers/docs/proto3#json).

This is causing an issue in the golang from jsonschema generator: https://github.com/googleapis/google-cloudevents-go/issues/22

---

I used the master branch of the `protoc-gen-jsonschema` tool to get this fix.

See issue: https://github.com/chrusty/protoc-gen-jsonschema/issues/47