### PR TITLE
Modifies the CloudEvent JSON schema to Have Accurate Field Names

### DIFF
--- a/jsonschema/google/events/cloud/audit/v1/LogEntryData.json
+++ b/jsonschema/google/events/cloud/audit/v1/LogEntryData.json
@@ -1,7 +1,8 @@
 {
   "$id": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/cloud/audit/v1/LogEntryData.json",
   "name": "LogEntryData",
-  "cloudevent": "google.events.cloud.audit.v1",
+  "package": "google.events.cloud.audit.v1",
+  "datatype": "google.events.cloud.audit.v1.LogEntryData",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {
     "logName": {

--- a/jsonschema/google/events/cloud/cloudbuild/v1/BuildEventData.json
+++ b/jsonschema/google/events/cloud/cloudbuild/v1/BuildEventData.json
@@ -1,7 +1,8 @@
 {
   "$id": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/cloud/cloudbuild/v1/BuildEventData.json",
   "name": "BuildEventData",
-  "cloudevent": "google.events.cloud.cloudbuild.v1",
+  "package": "google.events.cloud.cloudbuild.v1",
+  "datatype": "google.events.cloud.cloudbuild.v1.BuildEventData",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {
     "id": {

--- a/jsonschema/google/events/cloud/firestore/v1/DocumentEventData.json
+++ b/jsonschema/google/events/cloud/firestore/v1/DocumentEventData.json
@@ -1,7 +1,8 @@
 {
   "$id": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/cloud/firestore/v1/DocumentEventData.json",
   "name": "DocumentEventData",
-  "cloudevent": "google.events.cloud.firestore.v1",
+  "package": "google.events.cloud.firestore.v1",
+  "datatype": "google.events.cloud.firestore.v1.DocumentEventData",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {
     "value": {

--- a/jsonschema/google/events/cloud/pubsub/v1/MessagePublishedData.json
+++ b/jsonschema/google/events/cloud/pubsub/v1/MessagePublishedData.json
@@ -1,7 +1,8 @@
 {
   "$id": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/cloud/pubsub/v1/MessagePublishedData.json",
   "name": "MessagePublishedData",
-  "cloudevent": "google.events.cloud.pubsub.v1",
+  "package": "google.events.cloud.pubsub.v1",
+  "datatype": "google.events.cloud.pubsub.v1.MessagePublishedData",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {
     "message": {

--- a/jsonschema/google/events/cloud/scheduler/v1/SchedulerJobData.json
+++ b/jsonschema/google/events/cloud/scheduler/v1/SchedulerJobData.json
@@ -1,7 +1,8 @@
 {
   "$id": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/cloud/scheduler/v1/SchedulerJobData.json",
   "name": "SchedulerJobData",
-  "cloudevent": "google.events.cloud.scheduler.v1",
+  "package": "google.events.cloud.scheduler.v1",
+  "datatype": "google.events.cloud.scheduler.v1.SchedulerJobData",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {
     "customData": {

--- a/jsonschema/google/events/cloud/storage/v1/StorageObjectData.json
+++ b/jsonschema/google/events/cloud/storage/v1/StorageObjectData.json
@@ -1,7 +1,8 @@
 {
   "$id": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/cloud/storage/v1/StorageObjectData.json",
   "name": "StorageObjectData",
-  "cloudevent": "google.events.cloud.storage.v1",
+  "package": "google.events.cloud.storage.v1",
+  "datatype": "google.events.cloud.storage.v1.StorageObjectData",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {
     "contentEncoding": {

--- a/jsonschema/google/events/firebase/analytics/v1/AnalyticsLogData.json
+++ b/jsonschema/google/events/firebase/analytics/v1/AnalyticsLogData.json
@@ -1,7 +1,8 @@
 {
   "$id": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/firebase/analytics/v1/AnalyticsLogData.json",
   "name": "AnalyticsLogData",
-  "cloudevent": "google.events.firebase.analytics.v1",
+  "package": "google.events.firebase.analytics.v1",
+  "datatype": "google.events.firebase.analytics.v1.AnalyticsLogData",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {
     "userDim": {

--- a/jsonschema/google/events/firebase/auth/v1/AuthEventData.json
+++ b/jsonschema/google/events/firebase/auth/v1/AuthEventData.json
@@ -1,7 +1,8 @@
 {
   "$id": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/firebase/auth/v1/AuthEventData.json",
   "name": "AuthEventData",
-  "cloudevent": "google.events.firebase.auth.v1",
+  "package": "google.events.firebase.auth.v1",
+  "datatype": "google.events.firebase.auth.v1.AuthEventData",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {
     "uid": {

--- a/jsonschema/google/events/firebase/database/v1/ReferenceEventData.json
+++ b/jsonschema/google/events/firebase/database/v1/ReferenceEventData.json
@@ -1,7 +1,8 @@
 {
   "$id": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/firebase/database/v1/ReferenceEventData.json",
   "name": "ReferenceEventData",
-  "cloudevent": "google.events.firebase.database.v1",
+  "package": "google.events.firebase.database.v1",
+  "datatype": "google.events.firebase.database.v1.ReferenceEventData",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {
     "data": {

--- a/jsonschema/google/events/firebase/remoteconfig/v1/RemoteConfigEventData.json
+++ b/jsonschema/google/events/firebase/remoteconfig/v1/RemoteConfigEventData.json
@@ -1,7 +1,8 @@
 {
   "$id": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/firebase/remoteconfig/v1/RemoteConfigEventData.json",
   "name": "RemoteConfigEventData",
-  "cloudevent": "google.events.firebase.remoteconfig.v1",
+  "package": "google.events.firebase.remoteconfig.v1",
+  "datatype": "google.events.firebase.remoteconfig.v1.RemoteConfigEventData",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {
     "versionNumber": {

--- a/tools/proto2jsonschema/postgen.js
+++ b/tools/proto2jsonschema/postgen.js
@@ -17,15 +17,19 @@ console.log(`Fixing paths in dir: ${ROOT}`);
   const filePaths = await recursive(ROOT);
   // For every file
   filePaths.map(filePath => {
-    const dataName = path.basename(filePath,  path.extname(filePath)); // i.e. LogEntryData
+    const name = path.basename(filePath,  path.extname(filePath)); // i.e. LogEntryData
     
     // Create the modified JSON schema output
     const json = JSON.parse(fs.readFileSync(filePath).toString());
+    const $id = getId(filePath);
+    const cloudeventPackage = getCloudEventType(filePath);
+    // console.log(filePath);
+    // Add additional metadata to the JSON schema
     const resultJSON = {
-      // Add the $id and name first
-      $id: getId(filePath),
-      name: dataName,
-      cloudevent: getCloudEventType(filePath),
+      $id,
+      name,
+      package: cloudeventPackage,
+      datatype: `${cloudeventPackage}.${name}`,
       // Add all other fields. Convert keys to camelCase (i.e. remove snake_case keys)
       ...camelcaseKeys(json, {deep: true})
     };


### PR DESCRIPTION
Updates the CloudEvent JSON schema to have accurate field names.

- The field `cloudevent` isn't accurate here as this is not the ID for the CloudEvent (it doesn't include the name).
- The field `package` is the package in which this event lives, excluding the `name`.
- The field `datatype` is the full type of the `data` that this schema represents. = `package` + `name`.