### PR TITLE
ci: run build and git diff in same github workflow job

### DIFF
--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -16,10 +16,5 @@ jobs:
         go-version: '1.14'
     # Run the generators
     - run: ./scripts/gen.sh
-  validate:
-    runs-on: ubuntu-18.04
-    steps:
-    - name: Check out our repo
-      uses: actions/checkout@v2
     # Ensure there is no diff, otherwise we need to run the generator.
     - run: git diff --exit-code .


### PR DESCRIPTION
Fixes the CI git diff check.

Runs the generator and diff in the same CI job.
They cannot be run in parallel, it must be sequential (gen then diff).

CI should purposefully fail due to https://github.com/googleapis/google-cloudevents/issues/126.