### PR TITLE
fix: Fix CI. Regen with latest Chrusty plugin.

### DIFF
--- a/jsonschema/google/events/cloud/audit/v1/LogEntryData.json
+++ b/jsonschema/google/events/cloud/audit/v1/LogEntryData.json
@@ -71,14 +71,8 @@
           "properties": {
             "fields": {
               "additionalProperties": {
-                "oneOf": [
-                  {
-                    "type": "null"
-                  },
-                  {
-                    "type": "object"
-                  }
-                ]
+                "additionalProperties": true,
+                "type": "object"
               },
               "type": "object",
               "description": "Unordered map of dynamically typed values."
@@ -140,14 +134,8 @@
               "properties": {
                 "fields": {
                   "additionalProperties": {
-                    "oneOf": [
-                      {
-                        "type": "null"
-                      },
-                      {
-                        "type": "object"
-                      }
-                    ]
+                    "additionalProperties": true,
+                    "type": "object"
                   },
                   "type": "object",
                   "description": "Unordered map of dynamically typed values."
@@ -174,14 +162,8 @@
                         "properties": {
                           "fields": {
                             "additionalProperties": {
-                              "oneOf": [
-                                {
-                                  "type": "null"
-                                },
-                                {
-                                  "type": "object"
-                                }
-                              ]
+                              "additionalProperties": true,
+                              "type": "object"
                             },
                             "type": "object",
                             "description": "Unordered map of dynamically typed values."
@@ -202,14 +184,8 @@
                         "properties": {
                           "fields": {
                             "additionalProperties": {
-                              "oneOf": [
-                                {
-                                  "type": "null"
-                                },
-                                {
-                                  "type": "object"
-                                }
-                              ]
+                              "additionalProperties": true,
+                              "type": "object"
                             },
                             "type": "object",
                             "description": "Unordered map of dynamically typed values."
@@ -375,14 +351,8 @@
                       "properties": {
                         "fields": {
                           "additionalProperties": {
-                            "oneOf": [
-                              {
-                                "type": "null"
-                              },
-                              {
-                                "type": "object"
-                              }
-                            ]
+                            "additionalProperties": true,
+                            "type": "object"
                           },
                           "type": "object",
                           "description": "Unordered map of dynamically typed values."
@@ -448,14 +418,8 @@
           "properties": {
             "fields": {
               "additionalProperties": {
-                "oneOf": [
-                  {
-                    "type": "null"
-                  },
-                  {
-                    "type": "object"
-                  }
-                ]
+                "additionalProperties": true,
+                "type": "object"
               },
               "type": "object",
               "description": "Unordered map of dynamically typed values."
@@ -469,14 +433,8 @@
           "properties": {
             "fields": {
               "additionalProperties": {
-                "oneOf": [
-                  {
-                    "type": "null"
-                  },
-                  {
-                    "type": "object"
-                  }
-                ]
+                "additionalProperties": true,
+                "type": "object"
               },
               "type": "object",
               "description": "Unordered map of dynamically typed values."
@@ -490,14 +448,8 @@
           "properties": {
             "fields": {
               "additionalProperties": {
-                "oneOf": [
-                  {
-                    "type": "null"
-                  },
-                  {
-                    "type": "object"
-                  }
-                ]
+                "additionalProperties": true,
+                "type": "object"
               },
               "type": "object",
               "description": "Unordered map of dynamically typed values."
@@ -511,14 +463,8 @@
           "properties": {
             "fields": {
               "additionalProperties": {
-                "oneOf": [
-                  {
-                    "type": "null"
-                  },
-                  {
-                    "type": "object"
-                  }
-                ]
+                "additionalProperties": true,
+                "type": "object"
               },
               "type": "object",
               "description": "Unordered map of dynamically typed values."
@@ -578,6 +524,26 @@
       "format": "date-time"
     },
     "severity": {
+      "enum": [
+        "DEFAULT",
+        0,
+        "DEBUG",
+        100,
+        "INFO",
+        200,
+        "NOTICE",
+        300,
+        "WARNING",
+        400,
+        "ERROR",
+        500,
+        "CRITICAL",
+        600,
+        "ALERT",
+        700,
+        "EMERGENCY",
+        800
+      ],
       "oneOf": [
         {
           "type": "string"

--- a/jsonschema/google/events/cloud/audit/v1/LogEntryData.json
+++ b/jsonschema/google/events/cloud/audit/v1/LogEntryData.json
@@ -1,6 +1,7 @@
 {
   "$id": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/cloud/audit/v1/LogEntryData.json",
   "name": "LogEntryData",
+  "examples": [],
   "package": "google.events.cloud.audit.v1",
   "datatype": "google.events.cloud.audit.v1.LogEntryData",
   "cloudeventTypes": [

--- a/jsonschema/google/events/cloud/cloudbuild/v1/BuildEventData.json
+++ b/jsonschema/google/events/cloud/cloudbuild/v1/BuildEventData.json
@@ -58,13 +58,11 @@
         "storageSource": {
           "$ref": "#/definitions/StorageSource",
           "additionalProperties": true,
-          "type": "object",
           "description": "If provided, get the source from this location in Google Cloud Storage."
         },
         "repoSource": {
           "$ref": "#/definitions/RepoSource",
           "additionalProperties": true,
-          "type": "object",
           "description": "If provided, get the source from this location in a Cloud Source\n Repository."
         }
       },
@@ -129,13 +127,11 @@
           "timing": {
             "$ref": "#/definitions/TimeSpan",
             "additionalProperties": true,
-            "type": "object",
             "description": "Stores timing information for executing this build step."
           },
           "pullTiming": {
             "$ref": "#/definitions/TimeSpan",
             "additionalProperties": true,
-            "type": "object",
             "description": "Stores timing information for pulling this build step's\n builder image only."
           },
           "timeout": {
@@ -154,6 +150,26 @@
             "description": "Time limit for executing this build step. If not defined, the step has no\n time limit and will be allowed to continue to run until either it completes\n or the build itself times out."
           },
           "status": {
+            "enum": [
+              "STATUS_UNKNOWN",
+              0,
+              "QUEUED",
+              1,
+              "WORKING",
+              2,
+              "SUCCESS",
+              3,
+              "FAILURE",
+              4,
+              "INTERNAL_ERROR",
+              5,
+              "TIMEOUT",
+              6,
+              "CANCELLED",
+              7,
+              "EXPIRED",
+              9
+            ],
             "oneOf": [
               {
                 "type": "string"
@@ -188,7 +204,6 @@
               "pushTiming": {
                 "$ref": "#/definitions/TimeSpan",
                 "additionalProperties": true,
-                "type": "object",
                 "description": "Stores timing information for pushing the specified image."
               }
             },
@@ -224,7 +239,6 @@
         "artifactTiming": {
           "$ref": "#/definitions/TimeSpan",
           "additionalProperties": true,
-          "type": "object",
           "description": "Time to push all non-container artifacts."
         }
       },
@@ -309,7 +323,6 @@
             "timing": {
               "$ref": "#/definitions/TimeSpan",
               "additionalProperties": true,
-              "type": "object",
               "description": "Stores timing information for pushing all artifact objects."
             }
           },
@@ -331,13 +344,11 @@
         "resolvedStorageSource": {
           "$ref": "#/definitions/StorageSource",
           "additionalProperties": true,
-          "type": "object",
           "description": "A copy of the build's `source.storage_source`, if exists, with any\n generations resolved."
         },
         "resolvedRepoSource": {
           "$ref": "#/definitions/RepoSource",
           "additionalProperties": true,
-          "type": "object",
           "description": "A copy of the build's `source.repo_source`, if exists, with any\n revisions resolved."
         },
         "fileHashes": {
@@ -397,13 +408,13 @@
       "properties": {
         "sourceProvenanceHash": {
           "items": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "integer"
-              }
+            "enum": [
+              "NONE",
+              0,
+              "SHA256",
+              1,
+              "MD5",
+              2
             ]
           },
           "type": "array",
@@ -577,8 +588,7 @@
     "timing": {
       "additionalProperties": {
         "$ref": "#/definitions/TimeSpan",
-        "additionalProperties": true,
-        "type": "object"
+        "additionalProperties": true
       },
       "type": "object",
       "description": "Stores timing information for phases of the build. Valid keys\n are:\n\n * BUILD: time to execute all build steps\n * PUSH: time to push all specified images.\n * FETCHSOURCE: time to fetch source.\n\n If the build does not specify source or images,\n these keys will not be included."

--- a/jsonschema/google/events/cloud/cloudbuild/v1/BuildEventData.json
+++ b/jsonschema/google/events/cloud/cloudbuild/v1/BuildEventData.json
@@ -1,6 +1,7 @@
 {
   "$id": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/cloud/cloudbuild/v1/BuildEventData.json",
   "name": "BuildEventData",
+  "examples": [],
   "package": "google.events.cloud.cloudbuild.v1",
   "datatype": "google.events.cloud.cloudbuild.v1.BuildEventData",
   "cloudeventTypes": [

--- a/jsonschema/google/events/cloud/firestore/v1/DocumentEventData.json
+++ b/jsonschema/google/events/cloud/firestore/v1/DocumentEventData.json
@@ -1,6 +1,7 @@
 {
   "$id": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/cloud/firestore/v1/DocumentEventData.json",
   "name": "DocumentEventData",
+  "examples": [],
   "package": "google.events.cloud.firestore.v1",
   "datatype": "google.events.cloud.firestore.v1.DocumentEventData",
   "cloudeventTypes": [

--- a/jsonschema/google/events/cloud/firestore/v1/DocumentEventData.json
+++ b/jsonschema/google/events/cloud/firestore/v1/DocumentEventData.json
@@ -16,13 +16,11 @@
     "value": {
       "$ref": "#/definitions/Document",
       "additionalProperties": true,
-      "type": "object",
       "description": "A Document object containing a post-operation document snapshot.\n This is not populated for delete events. (TODO: check this!)"
     },
     "oldValue": {
       "$ref": "#/definitions/Document",
       "additionalProperties": true,
-      "type": "object",
       "description": "A Document object containing a pre-operation document snapshot.\n This is only populated for update and delete events."
     },
     "updateMask": {
@@ -53,8 +51,7 @@
         "fields": {
           "additionalProperties": {
             "$ref": "#/definitions/Value",
-            "additionalProperties": true,
-            "type": "object"
+            "additionalProperties": true
           },
           "type": "object",
           "description": "The document's fields.\n\n The map keys represent field names.\n\n A simple field name contains only characters `a` to `z`, `A` to `Z`,\n `0` to `9`, or `_`, and must not start with `0` to `9`. For example,\n `foo_bar_17`.\n\n Field names matching the regular expression `__.*__` are reserved. Reserved\n field names are forbidden except in certain documented contexts. The map\n keys, represented as UTF-8, must not exceed 1,500 bytes and cannot be\n empty.\n\n Field paths may be used in other contexts to refer to structured fields\n defined here. For `map_value`, the field path is represented by the simple\n or quoted field names of the containing fields, delimited by `.`. For\n example, the structured field\n `\"foo\" : { map_value: { \"x&y\" : { string_value: \"hello\" }}}` would be\n represented by the field path `foo.x&y`.\n\n Within a field path, a quoted field name starts and ends with `` ` `` and\n may contain any character. Some characters, including `` ` ``, must be\n escaped using a `\\`. For example, `` `x&y` `` represents `x&y` and\n `` `bak\\`tik` `` represents `` bak`tik ``."
@@ -78,6 +75,10 @@
     "Value": {
       "properties": {
         "nullValue": {
+          "enum": [
+            "NULL_VALUE",
+            0
+          ],
           "oneOf": [
             {
               "type": "string"
@@ -151,8 +152,7 @@
             "fields": {
               "additionalProperties": {
                 "$ref": "#/definitions/Value",
-                "additionalProperties": true,
-                "type": "object"
+                "additionalProperties": true
               },
               "type": "object",
               "description": "The map's fields.\n\n The map keys represent field names. Field names matching the regular\n expression `__.*__` are reserved. Reserved field names are forbidden except\n in certain documented contexts. The map keys, represented as UTF-8, must\n not exceed 1,500 bytes and cannot be empty."

--- a/jsonschema/google/events/cloud/pubsub/v1/MessagePublishedData.json
+++ b/jsonschema/google/events/cloud/pubsub/v1/MessagePublishedData.json
@@ -1,6 +1,7 @@
 {
   "$id": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/cloud/pubsub/v1/MessagePublishedData.json",
   "name": "MessagePublishedData",
+  "examples": [],
   "package": "google.events.cloud.pubsub.v1",
   "datatype": "google.events.cloud.pubsub.v1.MessagePublishedData",
   "cloudeventTypes": [

--- a/jsonschema/google/events/cloud/scheduler/v1/SchedulerJobData.json
+++ b/jsonschema/google/events/cloud/scheduler/v1/SchedulerJobData.json
@@ -1,6 +1,7 @@
 {
   "$id": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/cloud/scheduler/v1/SchedulerJobData.json",
   "name": "SchedulerJobData",
+  "examples": [],
   "package": "google.events.cloud.scheduler.v1",
   "datatype": "google.events.cloud.scheduler.v1.SchedulerJobData",
   "cloudeventTypes": [

--- a/jsonschema/google/events/cloud/storage/v1/StorageObjectData.json
+++ b/jsonschema/google/events/cloud/storage/v1/StorageObjectData.json
@@ -1,6 +1,7 @@
 {
   "$id": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/cloud/storage/v1/StorageObjectData.json",
   "name": "StorageObjectData",
+  "examples": [],
   "package": "google.events.cloud.storage.v1",
   "datatype": "google.events.cloud.storage.v1.StorageObjectData",
   "cloudeventTypes": [

--- a/jsonschema/google/events/firebase/analytics/v1/AnalyticsLogData.json
+++ b/jsonschema/google/events/firebase/analytics/v1/AnalyticsLogData.json
@@ -26,7 +26,6 @@
               "value": {
                 "$ref": "#/definitions/AnalyticsValue",
                 "additionalProperties": true,
-                "type": "object",
                 "description": "Last set value of user property."
               },
               "setTimestampUsec": {
@@ -213,8 +212,7 @@
           "params": {
             "additionalProperties": {
               "$ref": "#/definitions/AnalyticsValue",
-              "additionalProperties": true,
-              "type": "object"
+              "additionalProperties": true
             },
             "type": "object",
             "description": "A repeated record of the parameters associated with this event."

--- a/jsonschema/google/events/firebase/analytics/v1/AnalyticsLogData.json
+++ b/jsonschema/google/events/firebase/analytics/v1/AnalyticsLogData.json
@@ -1,6 +1,7 @@
 {
   "$id": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/firebase/analytics/v1/AnalyticsLogData.json",
   "name": "AnalyticsLogData",
+  "examples": [],
   "package": "google.events.firebase.analytics.v1",
   "datatype": "google.events.firebase.analytics.v1.AnalyticsLogData",
   "cloudeventTypes": [

--- a/jsonschema/google/events/firebase/auth/v1/AuthEventData.json
+++ b/jsonschema/google/events/firebase/auth/v1/AuthEventData.json
@@ -91,14 +91,8 @@
       "properties": {
         "fields": {
           "additionalProperties": {
-            "oneOf": [
-              {
-                "type": "null"
-              },
-              {
-                "type": "object"
-              }
-            ]
+            "additionalProperties": true,
+            "type": "object"
           },
           "type": "object",
           "description": "Unordered map of dynamically typed values."

--- a/jsonschema/google/events/firebase/auth/v1/AuthEventData.json
+++ b/jsonschema/google/events/firebase/auth/v1/AuthEventData.json
@@ -1,6 +1,7 @@
 {
   "$id": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/firebase/auth/v1/AuthEventData.json",
   "name": "AuthEventData",
+  "examples": [],
   "package": "google.events.firebase.auth.v1",
   "datatype": "google.events.firebase.auth.v1.AuthEventData",
   "cloudeventTypes": [

--- a/jsonschema/google/events/firebase/database/v1/ReferenceEventData.json
+++ b/jsonschema/google/events/firebase/database/v1/ReferenceEventData.json
@@ -1,6 +1,7 @@
 {
   "$id": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/firebase/database/v1/ReferenceEventData.json",
   "name": "ReferenceEventData",
+  "examples": [],
   "package": "google.events.firebase.database.v1",
   "datatype": "google.events.firebase.database.v1.ReferenceEventData",
   "cloudeventTypes": [

--- a/jsonschema/google/events/firebase/database/v1/ReferenceEventData.json
+++ b/jsonschema/google/events/firebase/database/v1/ReferenceEventData.json
@@ -14,24 +14,14 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {
     "data": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "object"
-        }
-      ]
+      "additionalProperties": true,
+      "type": "object",
+      "description": "The original data for the reference."
     },
     "delta": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "object"
-        }
-      ]
+      "additionalProperties": true,
+      "type": "object",
+      "description": "The change in the reference data."
     }
   },
   "additionalProperties": true,

--- a/jsonschema/google/events/firebase/remoteconfig/v1/RemoteConfigEventData.json
+++ b/jsonschema/google/events/firebase/remoteconfig/v1/RemoteConfigEventData.json
@@ -1,6 +1,7 @@
 {
   "$id": "https://googleapis.github.io/google-cloudevents/jsonschema/google/events/firebase/remoteconfig/v1/RemoteConfigEventData.json",
   "name": "RemoteConfigEventData",
+  "examples": [],
   "package": "google.events.firebase.remoteconfig.v1",
   "datatype": "google.events.firebase.remoteconfig.v1.RemoteConfigEventData",
   "cloudeventTypes": [

--- a/jsonschema/google/events/firebase/remoteconfig/v1/RemoteConfigEventData.json
+++ b/jsonschema/google/events/firebase/remoteconfig/v1/RemoteConfigEventData.json
@@ -43,6 +43,16 @@
       "description": "The user-provided description of the corresponding Remote Config template."
     },
     "updateOrigin": {
+      "enum": [
+        "REMOTE_CONFIG_UPDATE_ORIGIN_UNSPECIFIED",
+        0,
+        "CONSOLE",
+        1,
+        "REST_API",
+        2,
+        "ADMIN_SDK_NODE",
+        3
+      ],
       "oneOf": [
         {
           "type": "string"
@@ -54,6 +64,16 @@
       "description": "Where the update action originated."
     },
     "updateType": {
+      "enum": [
+        "REMOTE_CONFIG_UPDATE_TYPE_UNSPECIFIED",
+        0,
+        "INCREMENTAL_UPDATE",
+        1,
+        "FORCED_UPDATE",
+        2,
+        "ROLLBACK",
+        3
+      ],
       "oneOf": [
         {
           "type": "string"

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+# Clean directory and cache
+go clean -cache
+rm -rf $GOPATH/src/github.com/
+
+echo "Done"

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -24,14 +24,14 @@ esac
 rm -rf tmp
 mkdir tmp
 cd tmp
-echo "Downloading protobuf tools"
+echo "- Downloading protobuf@$PROTOBUF_VERSION"
 curl -sSL \
   https://github.com/protocolbuffers/protobuf/releases/download/v$PROTOBUF_VERSION/protoc-$PROTOBUF_VERSION-$PROTOBUF_PLATFORM.zip \
   --output protobuf.zip
 unzip -q protobuf.zip
 cd ..
 
-echo "Compiling protos as a descriptor set"
+echo "- Compiling protos as a descriptor set"
 chmod +x $PROTOC
 
 $PROTOC \

--- a/scripts/gen.sh
+++ b/scripts/gen.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -e
 
+# Clean directory and cache
+go clean -cache
+rm -rf $GOPATH/src/github.com/
+
 ## Generate JSON schemas
 ./tools/proto2jsonschema/gen.sh
 

--- a/scripts/gen.sh
+++ b/scripts/gen.sh
@@ -1,10 +1,6 @@
 #!/bin/bash
 set -e
 
-# Clean directory and cache
-go clean -cache
-rm -rf $GOPATH/src/github.com/
-
 ## Generate JSON schemas
 ./tools/proto2jsonschema/gen.sh
 

--- a/tools/jsonschema-catalog/gen.sh
+++ b/tools/jsonschema-catalog/gen.sh
@@ -2,8 +2,8 @@
 
 set -e
 
-echo "- Gen catalog"
+echo "- Catalog: Gen start"
 cd $(dirname $0)
 npm i
 node .
-echo "- End"
+echo "- Catalog: Gen end"

--- a/tools/proto2jsonschema/gen.sh
+++ b/tools/proto2jsonschema/gen.sh
@@ -29,21 +29,22 @@ case "$OSTYPE" in
     exit 1
 esac
 
+PROTOBUF_VERSION=3.12.3
 rm -rf tmp
 mkdir tmp
 cd tmp
-echo "- Downloading protobuf tools"
-PROTOBUF_VERSION=3.12.3
+echo "- Downloading protobuf@$PROTOBUF_VERSION"
 curl -sSL \
   https://github.com/protocolbuffers/protobuf/releases/download/v$PROTOBUF_VERSION/protoc-$PROTOBUF_VERSION-$PROTOBUF_PLATFORM.zip \
   --output protobuf.zip
 unzip -q protobuf.zip
 cd ..
 
-echo "- Setting up protoc plugin (chrusty/protoc-gen-jsonschema)"
+PROTOC_PLUGING_VERSION=0.9.7
+echo "- Setting up protoc plugin: chrusty/protoc-gen-jsonschema@$PROTOC_PLUGING_VERSION"
 # Pin chrusty tool to specific version: https://github.com/chrusty/protoc-gen-jsonschema/tags
 go get -v github.com/chrusty/protoc-gen-jsonschema/cmd/protoc-gen-jsonschema
-GO111MODULE=on go get -v github.com/chrusty/protoc-gen-jsonschema/cmd/protoc-gen-jsonschema@0.9.7
+GO111MODULE=on go get -v github.com/chrusty/protoc-gen-jsonschema/cmd/protoc-gen-jsonschema@$PROTOC_PLUGING_VERSION
 go install github.com/chrusty/protoc-gen-jsonschema/cmd/protoc-gen-jsonschema
 
 echo "- Converting protos to JSON Schemas"

--- a/tools/proto2jsonschema/gen.sh
+++ b/tools/proto2jsonschema/gen.sh
@@ -40,11 +40,11 @@ curl -sSL \
 unzip -q protobuf.zip
 cd ..
 
-PROTOC_PLUGING_VERSION=0.9.7
-echo "- Setting up protoc plugin: chrusty/protoc-gen-jsonschema@$PROTOC_PLUGING_VERSION"
+PROTOC_PLUGIN_VERSION=0.9.7
+echo "- Setting up protoc plugin: chrusty/protoc-gen-jsonschema@$PROTOC_PLUGIN_VERSION"
 # Pin chrusty tool to specific version: https://github.com/chrusty/protoc-gen-jsonschema/tags
 go get -v github.com/chrusty/protoc-gen-jsonschema/cmd/protoc-gen-jsonschema
-GO111MODULE=on go get -v github.com/chrusty/protoc-gen-jsonschema/cmd/protoc-gen-jsonschema@$PROTOC_PLUGING_VERSION
+GO111MODULE=on go get -v github.com/chrusty/protoc-gen-jsonschema/cmd/protoc-gen-jsonschema@$PROTOC_PLUGIN_VERSION
 go install github.com/chrusty/protoc-gen-jsonschema/cmd/protoc-gen-jsonschema
 
 echo "- Converting protos to JSON Schemas"

--- a/tools/readme-catalog/index.js
+++ b/tools/readme-catalog/index.js
@@ -48,7 +48,7 @@ const getSchemaLinkMarkdown = (schemaEntry) => {
 }
 
 (async () => {
-  console.log('Updating README...');
+  console.log('- Updating README...');
 
   // Generate table
   const replacementTableRow = (schemaEntry) => {
@@ -71,5 +71,5 @@ ${CATALOG.schemas.map(replacementTableRow).join('\n')}`;
 
   // Save updated README
   fs.writeFileSync(README_PATH, updatedReadmeContents);
-  console.log('Updated README.');
+  console.log('- Updated README.');
 })();


### PR DESCRIPTION
Now that we have CI checking that the full generation steps is working, this PR makes the CI pass (through a few adjustments).

- Ensures the chrusty protoc plugin that is specified is fixed
  - Ensures anyone running this locally doesn't use a cached version by deleting the cache beforehand.
- Latest crusty plugin has some updates:
  - Fixes bad `oneOf` types allowing nulls. https://github.com/chrusty/protoc-gen-jsonschema/commit/7726bafee96859cdee2947f818544b2af809be75
    - This is a good thing as having it causes complicated behavior in language clients.
  - Fixes enum values per: https://github.com/chrusty/protoc-gen-jsonschema/pull/44
- Slightly adjust output of generator scripts to be more readable and debuggable.
- Adds cleaning script for helping the system packages are correct.

You'll notice CI passes now. Fixes https://github.com/googleapis/google-cloudevents/issues/140.