### PR TITLE
fix: ignore the catalog when running qt

### DIFF
--- a/tools/quicktype-wrapper/package-lock.json
+++ b/tools/quicktype-wrapper/package-lock.json
@@ -2960,9 +2960,9 @@
       }
     },
     "urijs": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.2.tgz",
-      "integrity": "sha512-s/UIq9ap4JPZ7H1EB5ULo/aOUbWqfDi7FKzMC2Nz+0Si8GiT1rIEaprt8hy3Vy2Ex2aJPpOQv4P4DuOZ+K1c6w=="
+      "version": "1.19.5",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.5.tgz",
+      "integrity": "sha512-48z9VGWwdCV5KfizHsE05DWS5fhK6gFlx5MjO7xu0Krc5FGPWzjlXEVV0nPMrdVuP7xmMHiPZ2HoYZwKOFTZOg=="
     },
     "url-parse-lax": {
       "version": "3.0.0",
@@ -3000,9 +3000,9 @@
       "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow=="
     },
     "whatwg-fetch": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.4.1.tgz",
-      "integrity": "sha512-sofZVzE1wKwO+EYPbWfiwzaKovWiZXf4coEzjGP9b2GBVgQRLQUZ2QcuPpQExGDAW5GItpEm6Tl4OU5mywnAoQ=="
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.5.0.tgz",
+      "integrity": "sha512-jXkLtsR42xhXg7akoDKvKWE40eJeI+2KZqcp2h3NsOrRnDvtWX36KcKl30dy+hxECivdk2BVUHVNrPtoMBUx6A=="
     },
     "which": {
       "version": "2.0.2",

--- a/tools/quicktype-wrapper/package.json
+++ b/tools/quicktype-wrapper/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "mkdirp": "1.0.4",
-    "quicktype-core": "6.0.69",
+    "quicktype-core": "^6.0.69",
     "recursive-readdir": "2.2.2",
     "yargs": "16.1.0"
   }

--- a/tools/quicktype-wrapper/src/index.ts
+++ b/tools/quicktype-wrapper/src/index.ts
@@ -53,7 +53,7 @@ async function getJSONSchemasPaths(directory: string) {
   // The name of the JSON Schema file
   const SCHEMA_PATTERN = '*.json';
   // Ignore all files that don't match the SCHEMA_PATTERN.
-  const IGNORE_PATTERN = [`!${SCHEMA_PATTERN}`];
+  const IGNORE_PATTERN = [`!${SCHEMA_PATTERN}`, 'catalog.json'];
 
   console.log(`- Finding all JSON Schemas (${SCHEMA_PATTERN})...`);
   const paths: string[] = await recursive(directory, IGNORE_PATTERN);

--- a/tools/quicktype-wrapper/src/quickstype.ts
+++ b/tools/quicktype-wrapper/src/quickstype.ts
@@ -137,7 +137,10 @@ export async function jsonschema2languageFiles({
   typeName: string;
   language: TARGET_LANGUAGE | string;
 }): Promise<QtMultifileResult> {
-  // Run quicktype tooling
+  if (!jsonSchema) throw console.error('ERROR: jsonschema2languageFiles(): jsonSchema undefined');
+  if (!language) throw console.error('ERROR: jsonschema2languageFiles(): language undefined');
+  if (!typeName) throw console.error('ERROR: jsonschema2languageFiles(): typeName undefined');
+
   const multifileResult: MultiFileRenderResult = await quicktypeJSONSchemaToMultiFile(
     language,
     typeName,


### PR DESCRIPTION
This PR ensures the JSON schema `catalog.json` file isn't pulled in as a JSON schema input file.

Related: https://github.com/googleapis/google-cloudevents-python/pull/29