### PR TITLE
Rename fields in Firebase auth UserMetadata message

### DIFF
--- a/jsonschema/google/events/firebase/auth/v1/AuthEventData.json
+++ b/jsonschema/google/events/firebase/auth/v1/AuthEventData.json
@@ -37,12 +37,12 @@
     },
     "metadata": {
       "properties": {
-        "createdAt": {
+        "createTime": {
           "type": "string",
           "description": "The date the user was created.",
           "format": "date-time"
         },
-        "lastSignedInAt": {
+        "lastSignInTime": {
           "type": "string",
           "description": "The date the user last signed in.",
           "format": "date-time"

--- a/proto/google/events/firebase/auth/v1/data.proto
+++ b/proto/google/events/firebase/auth/v1/data.proto
@@ -58,10 +58,10 @@ message AuthEventData {
 // Additional metadata about the user.
 message UserMetadata {
   // The date the user was created.
-  google.protobuf.Timestamp created_at = 1;
+  google.protobuf.Timestamp create_time = 1;
 
   // The date the user last signed in.
-  google.protobuf.Timestamp last_signed_in_at = 2;
+  google.protobuf.Timestamp last_sign_in_time = 2;
 }
 
 // User's info at the identity provider


### PR DESCRIPTION
This allows them to conform with our API conventions better.
Functions Frameworks will need to perform appropriate conversions.