### PR TITLE
test: Ensure that both PubSub test events have messageId and publishTime

### DIFF
--- a/testdata/google/events/cloud/pubsub/v1/MessagePublishedData-binary.json
+++ b/testdata/google/events/cloud/pubsub/v1/MessagePublishedData-binary.json
@@ -3,6 +3,7 @@
   "message": {
     "@type": "type.googleapis.com/google.pubsub.v1.PubsubMessage",
     "data": "AQIDBA==",
-    "messageId": "message-id"
+    "messageId": "message-id",
+    "publishTime":"2021-02-05T04:06:14.109Z"
   }
 }

--- a/testdata/google/events/cloud/pubsub/v1/MessagePublishedData-text.json
+++ b/testdata/google/events/cloud/pubsub/v1/MessagePublishedData-text.json
@@ -5,6 +5,8 @@
     "attributes": {
       "attr1":"attr1-value"
     },
-    "data": "dGVzdCBtZXNzYWdlIDM="
+    "data": "dGVzdCBtZXNzYWdlIDM=",
+    "messageId": "message-id",
+    "publishTime":"2021-02-05T04:06:14.109Z"
   }
 }


### PR DESCRIPTION
The value for `publishTime` copied from #151, which contained an
observed payload from Eventarc.