### PR TITLE
ci: add PR generator workflow

### DIFF
--- a/.github/workflows/gen_pr.yaml
+++ b/.github/workflows/gen_pr.yaml
@@ -1,0 +1,54 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Run Generator and Create Pull Request
+on:
+  push:
+    branches:
+      - "master"
+jobs:
+  create_pr:
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Check out repo
+      uses: actions/checkout@v2
+    - name: Setup Node for gen/postgen scripts
+      uses: actions/setup-node@v2
+      with:
+        node-version: '12'
+    - name: Setup Go for proto2jsonschema script
+      uses: actions/setup-go@v2
+      with:
+        go-version: '1.14'
+    - name: Run the generators
+      run: ./scripts/gen.sh
+    - name: Commit changelog and manifest files
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        if [[ `git status --porcelain` ]]; then
+          # Changes after running generator
+          git config --global user.email "yoshi-code-bot@google.com"
+          git config --global user.name "Google Bot"
+          git checkout -b "pr_bot-$GITHUB_RUN_ID"
+          git add -A
+          NOW=$(date +"%m-%d-%Y")
+          git commit --message "feat: run generator (${NOW})"
+          git push origin "pr_bot-$GITHUB_RUN_ID"
+          echo "Created commit: $(git rev-parse HEAD)"
+          gh pr create --title "Run the generator (${NOW})" --body "AUTOMATED PR! This PR was created from a recent push to the default branch."
+        else
+          # No changes after running generator
+          echo "No PR to create."
+        fi

--- a/.github/workflows/gen_pr.yaml
+++ b/.github/workflows/gen_pr.yaml
@@ -37,8 +37,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
+        # If there is a non-zero diff after running generator
         if [[ `git status --porcelain` ]]; then
-          # Changes after running generator
           git config --global user.email "yoshi-code-bot@google.com"
           git config --global user.name "Google Bot"
           git checkout -b "pr_bot-$GITHUB_RUN_ID"
@@ -47,7 +47,9 @@ jobs:
           git commit --message "feat: run generator (${NOW})"
           git push origin "pr_bot-$GITHUB_RUN_ID"
           echo "Created commit: $(git rev-parse HEAD)"
-          gh pr create --title "Run the generator (${NOW})" --body "AUTOMATED PR! This PR was created from a recent push to the default branch."
+          gh pr create \
+            --title "Run the generator (${NOW})" \
+            --body "AUTOMATED PR! This PR was created from a recent push to the default branch. Please check to ensure there are no CI failures or unexpected generated results."
         else
           # No changes after running generator
           echo "No PR to create."


### PR DESCRIPTION
# ci: add PR generator GitHub workflow

This PR adds a workflow to this repo that creates PRs when a commit lands to `master` (conditionally if the diff contents is non-zero).

Generated PRs are expected to be reviewed by a human and manually merged.

Fixes: https://github.com/googleapis/google-cloudevents/issues/163

## Summary

**Event:** Push
**Branch:** `master`
**PR commit:**  `feat: run generator (${NOW})"`
**PR contents:** Runs the generator (`./scripts/gen.sh`)

## Example

<img width="931" alt="Screen Shot 2021-02-26 at 16 41 12" src="https://user-images.githubusercontent.com/744973/109363492-585be180-7852-11eb-9e98-687d4d67458a.png">

Example PR on a fork: https://github.com/grant/google-cloudevents/pull/4

## Detailed Design

Updated the GitHub workflow with the correct information:
- event (push to `master`)
- generator setup (same as compile CI setup)
- generator step (same as diff CI setup)
- git diff conditional (`git status --porcelain`)
- git configs
- unique git branch
- git commit message
- GitHub PR title and body

### Open Questions

- Do we want a different git email/name?
- Do we want to change the git commit message to something different? Is it possible to detect if a change is a `feat` or something else?

## Testing

Tested on a fork with a few PRs.
