### PR TITLE
chore: run the generator, feb 26, 2021

### DIFF
--- a/jsonschema/google/events/cloud/audit/v1/LogEntryData.json
+++ b/jsonschema/google/events/cloud/audit/v1/LogEntryData.json
@@ -107,7 +107,9 @@
                   },
                   "value": {
                     "type": "string",
-                    "description": "Must be a valid serialized protocol buffer of the above specified type."
+                    "description": "Must be a valid serialized protocol buffer of the above specified type.",
+                    "format": "binary",
+                    "binaryEncoding": "base64"
                   }
                 },
                 "additionalProperties": true,

--- a/jsonschema/google/events/cloud/cloudbuild/v1/BuildEventData.json
+++ b/jsonschema/google/events/cloud/cloudbuild/v1/BuildEventData.json
@@ -234,7 +234,9 @@
             "type": "string"
           },
           "type": "array",
-          "description": "List of build step outputs, produced by builder images, in the order\n corresponding to build step indices.\n\n [Cloud Builders](https://cloud.google.com/cloud-build/docs/cloud-builders)\n can produce this output by writing to `$BUILDER_OUTPUT/output`.\n Only the first 4KB of data is stored."
+          "description": "List of build step outputs, produced by builder images, in the order\n corresponding to build step indices.\n\n [Cloud Builders](https://cloud.google.com/cloud-build/docs/cloud-builders)\n can produce this output by writing to `$BUILDER_OUTPUT/output`.\n Only the first 4KB of data is stored.",
+          "format": "binary",
+          "binaryEncoding": "base64"
         },
         "artifactTiming": {
           "$ref": "#/definitions/TimeSpan",
@@ -378,7 +380,9 @@
                     },
                     "value": {
                       "type": "string",
-                      "description": "The hash value."
+                      "description": "The hash value.",
+                      "format": "binary",
+                      "binaryEncoding": "base64"
                     }
                   },
                   "additionalProperties": true,
@@ -572,7 +576,9 @@
           },
           "secretEnv": {
             "additionalProperties": {
-              "type": "string"
+              "type": "string",
+              "format": "binary",
+              "binaryEncoding": "base64"
             },
             "type": "object",
             "description": "Map of environment variable name to its encrypted value.\n\n Secret environment variables must be unique across all of a build's\n secrets, and must be used by at least one build step. Values can be at most\n 64 KB in size. There can be at most 100 secret values across all of a\n build's secrets."

--- a/jsonschema/google/events/cloud/firestore/v1/DocumentEventData.json
+++ b/jsonschema/google/events/cloud/firestore/v1/DocumentEventData.json
@@ -115,7 +115,9 @@
         },
         "bytesValue": {
           "type": "string",
-          "description": "A bytes value.\n\n Must not exceed 1 MiB - 89 bytes.\n Only the first 1,500 bytes are considered by queries."
+          "description": "A bytes value.\n\n Must not exceed 1 MiB - 89 bytes.\n Only the first 1,500 bytes are considered by queries.",
+          "format": "binary",
+          "binaryEncoding": "base64"
         },
         "referenceValue": {
           "type": "string",

--- a/jsonschema/google/events/cloud/pubsub/v1/MessagePublishedData.json
+++ b/jsonschema/google/events/cloud/pubsub/v1/MessagePublishedData.json
@@ -17,7 +17,9 @@
       "properties": {
         "data": {
           "type": "string",
-          "description": "The binary data in the message."
+          "description": "The binary data in the message.",
+          "format": "binary",
+          "binaryEncoding": "base64"
         },
         "attributes": {
           "additionalProperties": {

--- a/jsonschema/google/events/cloud/scheduler/v1/SchedulerJobData.json
+++ b/jsonschema/google/events/cloud/scheduler/v1/SchedulerJobData.json
@@ -12,7 +12,9 @@
   "properties": {
     "customData": {
       "type": "string",
-      "description": "The custom data the user specified when creating the scheduler source."
+      "description": "The custom data the user specified when creating the scheduler source.",
+      "format": "binary",
+      "binaryEncoding": "base64"
     }
   },
   "additionalProperties": true,


### PR DESCRIPTION
Runs the generator manually.

The latest change has improvements to metadata about base64 type strings.

Fixes: https://github.com/googleapis/google-cloudevents/issues/174