### PR TITLE
ci: run CI on windows

### DIFF
--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, windows-2019]
+        os: [windows-2019, ubuntu-18.04]
     steps:
     - name: Check out repo
       uses: actions/checkout@v2

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -16,7 +16,10 @@ name: Generate
 on: [push, pull_request]
 jobs:
   build:
-    runs-on: [self-hosted, ubuntu-18.04, windows-2019]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, windows-2019]
     steps:
     - name: Check out repo
       uses: actions/checkout@v2

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -16,7 +16,7 @@ name: Generate
 on: [push, pull_request]
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: [self-hosted, ubuntu-18.04, windows-2019]
     steps:
     - name: Check out repo
       uses: actions/checkout@v2


### PR DESCRIPTION
Runs generate CI on Windows to ensure generation works on that OS too.

See: https://github.com/googleapis/google-cloudevents/issues/154

I can't see a difference on Windows with the generation script, so I'm not sure exactly how to reproduce the issue. Unless, the reported issue is on a older version of Windows or version different than `windows-2019`.

