### PR TITLE
ci: fix copybara ci pr

### DIFF
--- a/.github/workflows/copybara.yaml
+++ b/.github/workflows/copybara.yaml
@@ -30,7 +30,7 @@ jobs:
         git config --global user.email "yoshi-code-bot@google.com"
         git config --global user.name "Yoshi Code Bot"
         gh pr create \
-        --base copybara \
-        --head master \
+        --base master \
+        --head copybara \
         --title "[Copybara] Update with new internal changes from Piper" \
         --body "This is a auto-generated pull request. The PR updates the default branch with new changes from the copybara branch. Refer to PR commit history for more details."


### PR DESCRIPTION
It turns out the copybara PR CI wasn't running because we mixed up the base and head branches. As a result, some previous runs of the action didn't trigger a PR. Example:

https://github.com/googleapis/google-cloudevents/runs/2188505173?check_suite_focus=true

This change correctly updates the action. Example PR:

https://github.com/googleapis/google-cloudevents/pull/198

---

Aside, as we update the `master` branch mandually, we'll want to keep up the `copybara` branch. We can do this separately.