### PR TITLE
Prototype of protobuf annotations to describe extension attributes

### DIFF
--- a/proto/google/events/cloud/audit/v1/events.proto
+++ b/proto/google/events/cloud/audit/v1/events.proto
@@ -22,9 +22,31 @@ import "google/events/cloudevent.proto";
 option csharp_namespace = "Google.Events.Protobuf.Cloud.Audit.V1";
 option (google.events.cloud_event_product) = "Cloud Audit Logs";
 
+option (google.events.cloud_event_extension_attribute) = {
+  name: "servicename"
+  description: "The name of the service which triggered the Cloud Audit log entry."
+  title_case_name: "ServiceName"
+};
+
+option (google.events.cloud_event_extension_attribute) = {
+  name: "methodname"
+  description: "The name of the method (RPC) triggering the Cloud Audit log entry."
+  title_case_name: "MethodName"
+};
+
+option (google.events.cloud_event_extension_attribute) = {
+  name: "resourcename"
+  description: "The name of the resource that is the subject of the Cloud Audit log entry."
+  title_case_name: "ResourceName"
+};
+
 // The CloudEvent raised when an audit log entry is written.
 message AuditLogWrittenEvent {
   option (google.events.cloud_event_type) = "google.cloud.audit.log.v1.written";
+
+  option (google.events.cloud_event_extension_name) = "servicename";
+  option (google.events.cloud_event_extension_name) = "methodname";
+  option (google.events.cloud_event_extension_name) = "resourcename";
 
   // The data associated with the event.
   LogEntryData data = 1;

--- a/proto/google/events/cloud/pubsub/v1/events.proto
+++ b/proto/google/events/cloud/pubsub/v1/events.proto
@@ -22,10 +22,16 @@ import "google/events/cloudevent.proto";
 option csharp_namespace = "Google.Events.Protobuf.Cloud.PubSub.V1";
 option (google.events.cloud_event_product) = "Cloud Pub/Sub";
 
+option (google.events.cloud_event_extension_attribute) = {
+  name: "topic"
+  description: "The Pub/Sub topic for which the message was published.",
+};
+
 // The CloudEvent raised when a PubSub message is published for a topic.
 message MessagePublishedEvent {
   option (google.events.cloud_event_type) =
       "google.cloud.pubsub.topic.v1.messagePublished";
+  option (google.events.cloud_event_extension_name) = "topic";
 
   // The data associated with the event.
   MessagePublishedData data = 1;

--- a/proto/google/events/cloudevent.proto
+++ b/proto/google/events/cloudevent.proto
@@ -31,3 +31,27 @@ extend google.protobuf.FileOptions {
   // in this file.
   string cloud_event_product = 11716487;
 }
+
+extend google.protobuf.FileOptions {
+  // An extension attribute used within the CloudEvents described in this file.
+  repeated ExtensionAttribute cloud_event_extension_attribute = 11716488;
+}
+
+extend google.protobuf.MessageOptions {
+  // The name of an extension attribute populated for this event. The extension
+  // attribute should be more fully described within the file options.
+  repeated string cloud_event_extension_name = 11716489;
+}
+
+// Description of an extension attribute.
+message ExtensionAttribute {
+  // Name of the CloudEvents attribute, e.g. "topic".
+  string name = 1;
+
+  // Description of the attribute.
+  string description = 2;
+
+  // The name of the CloudEvents attribute in title case, e.g. "FirebaseDatabaseHost".
+  // This only needs to be populated if the name would otherwise be mis-represented.
+  string title_case_name = 3;
+}


### PR DESCRIPTION
See https://github.com/googleapis/google-cloudevents-dotnet/pull/62 for an example of what we can do with this from a library perspective, as well as it just being useful in general.

The precise details of the annotations can certainly be changed - this is more of a sketch than anything else.
Note that when we decide we want to do this, we'll need to make the change internally first so that it will then be propagated.