### PR TITLE
feat: Add enum to string option for qt

### DIFF
--- a/tools/quicktype-wrapper/README.md
+++ b/tools/quicktype-wrapper/README.md
@@ -31,6 +31,7 @@ To configure the script, use _environment variables_ or _command-line flags_:
 
 - (REQUIRED) `IN`: Input directory path.
 - (REQUIRED) `OUT`: Output directory path.
+- (NOT REQUIRED) `ENUM_AS_STRING`: Set to `true` to treat JSON schema fields with enum values as strings.
 - (NOT REQUIRED) `NO_LICENSE`: Set to `true` to skip adding license headers to source files.
 
 ### Environment Variables


### PR DESCRIPTION
Adds option for qt generator to treat enums as strings for client library conversion.

This enables clients to generate without using the JSON schema `oneOf` type, which we want to preserve semantically, but can cause issues with clients actually parsing JSON, which is a string, not a oneOf string|int.

This feature is required for fixing the golang client:
- See https://github.com/googleapis/google-cloudevents-go/issues/68