### PR TITLE
feat: improve jsonschema types for protobuf well known types

### DIFF
--- a/jsonschema/google/events/cloud/audit/v1/LogEntryData.json
+++ b/jsonschema/google/events/cloud/audit/v1/LogEntryData.json
@@ -73,8 +73,23 @@
           "properties": {
             "fields": {
               "additionalProperties": {
-                "additionalProperties": true,
-                "type": "object"
+                "oneOf": [
+                  {
+                    "type": "array"
+                  },
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "object"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
               },
               "type": "object",
               "description": "Unordered map of dynamically typed values."
@@ -107,7 +122,9 @@
                   },
                   "value": {
                     "type": "string",
-                    "description": "Must be a valid serialized protocol buffer of the above specified type."
+                    "description": "Must be a valid serialized protocol buffer of the above specified type.",
+                    "format": "binary",
+                    "binaryEncoding": "base64"
                   }
                 },
                 "additionalProperties": true,
@@ -136,8 +153,23 @@
               "properties": {
                 "fields": {
                   "additionalProperties": {
-                    "additionalProperties": true,
-                    "type": "object"
+                    "oneOf": [
+                      {
+                        "type": "array"
+                      },
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "object"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
                   },
                   "type": "object",
                   "description": "Unordered map of dynamically typed values."
@@ -164,8 +196,23 @@
                         "properties": {
                           "fields": {
                             "additionalProperties": {
-                              "additionalProperties": true,
-                              "type": "object"
+                              "oneOf": [
+                                {
+                                  "type": "array"
+                                },
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "object"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ]
                             },
                             "type": "object",
                             "description": "Unordered map of dynamically typed values."
@@ -186,8 +233,23 @@
                         "properties": {
                           "fields": {
                             "additionalProperties": {
-                              "additionalProperties": true,
-                              "type": "object"
+                              "oneOf": [
+                                {
+                                  "type": "array"
+                                },
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "object"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ]
                             },
                             "type": "object",
                             "description": "Unordered map of dynamically typed values."
@@ -353,8 +415,23 @@
                       "properties": {
                         "fields": {
                           "additionalProperties": {
-                            "additionalProperties": true,
-                            "type": "object"
+                            "oneOf": [
+                              {
+                                "type": "array"
+                              },
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "object"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ]
                           },
                           "type": "object",
                           "description": "Unordered map of dynamically typed values."
@@ -420,8 +497,23 @@
           "properties": {
             "fields": {
               "additionalProperties": {
-                "additionalProperties": true,
-                "type": "object"
+                "oneOf": [
+                  {
+                    "type": "array"
+                  },
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "object"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
               },
               "type": "object",
               "description": "Unordered map of dynamically typed values."
@@ -435,8 +527,23 @@
           "properties": {
             "fields": {
               "additionalProperties": {
-                "additionalProperties": true,
-                "type": "object"
+                "oneOf": [
+                  {
+                    "type": "array"
+                  },
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "object"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
               },
               "type": "object",
               "description": "Unordered map of dynamically typed values."
@@ -450,8 +557,23 @@
           "properties": {
             "fields": {
               "additionalProperties": {
-                "additionalProperties": true,
-                "type": "object"
+                "oneOf": [
+                  {
+                    "type": "array"
+                  },
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "object"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
               },
               "type": "object",
               "description": "Unordered map of dynamically typed values."
@@ -465,8 +587,23 @@
           "properties": {
             "fields": {
               "additionalProperties": {
-                "additionalProperties": true,
-                "type": "object"
+                "oneOf": [
+                  {
+                    "type": "array"
+                  },
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "object"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
               },
               "type": "object",
               "description": "Unordered map of dynamically typed values."

--- a/jsonschema/google/events/cloud/cloudbuild/v1/BuildEventData.json
+++ b/jsonschema/google/events/cloud/cloudbuild/v1/BuildEventData.json
@@ -138,18 +138,8 @@
             "description": "Stores timing information for pulling this build step's\n builder image only."
           },
           "timeout": {
-            "properties": {
-              "seconds": {
-                "type": "integer",
-                "description": "Signed seconds of the span of time. Must be from -315,576,000,000\n to +315,576,000,000 inclusive. Note: these bounds are computed from:\n 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years"
-              },
-              "nanos": {
-                "type": "integer",
-                "description": "Signed fractions of a second at nanosecond resolution of the span\n of time. Durations less than one second are represented with a 0\n `seconds` field and a positive or negative `nanos` field. For durations\n of one second or more, a non-zero value for the `nanos` field must be\n of the same sign as the `seconds` field. Must be from -999,999,999\n to +999,999,999 inclusive."
-              }
-            },
             "additionalProperties": true,
-            "type": "object",
+            "type": "string",
             "description": "Time limit for executing this build step. If not defined, the step has no\n time limit and will be allowed to continue to run until either it completes\n or the build itself times out."
           },
           "status": {
@@ -237,7 +227,9 @@
             "type": "string"
           },
           "type": "array",
-          "description": "List of build step outputs, produced by builder images, in the order\n corresponding to build step indices.\n\n [Cloud Builders](https://cloud.google.com/cloud-build/docs/cloud-builders)\n can produce this output by writing to `$BUILDER_OUTPUT/output`.\n Only the first 4KB of data is stored."
+          "description": "List of build step outputs, produced by builder images, in the order\n corresponding to build step indices.\n\n [Cloud Builders](https://cloud.google.com/cloud-build/docs/cloud-builders)\n can produce this output by writing to `$BUILDER_OUTPUT/output`.\n Only the first 4KB of data is stored.",
+          "format": "binary",
+          "binaryEncoding": "base64"
         },
         "artifactTiming": {
           "$ref": "#/definitions/TimeSpan",
@@ -265,18 +257,8 @@
       "format": "date-time"
     },
     "timeout": {
-      "properties": {
-        "seconds": {
-          "type": "integer",
-          "description": "Signed seconds of the span of time. Must be from -315,576,000,000\n to +315,576,000,000 inclusive. Note: these bounds are computed from:\n 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years"
-        },
-        "nanos": {
-          "type": "integer",
-          "description": "Signed fractions of a second at nanosecond resolution of the span\n of time. Durations less than one second are represented with a 0\n `seconds` field and a positive or negative `nanos` field. For durations\n of one second or more, a non-zero value for the `nanos` field must be\n of the same sign as the `seconds` field. Must be from -999,999,999\n to +999,999,999 inclusive."
-        }
-      },
       "additionalProperties": true,
-      "type": "object",
+      "type": "string",
       "description": "Amount of time that this build should be allowed to run, to second\n granularity. If this amount of time elapses, work on the build will cease\n and the build status will be `TIMEOUT`."
     },
     "images": {
@@ -287,18 +269,8 @@
       "description": "A list of images to be pushed upon the successful completion of all build\n steps.\n\n The images are pushed using the builder service account's credentials.\n\n The digests of the pushed images will be stored in the `Build` resource's\n results field.\n\n If any of the images fail to be pushed, the build status is marked\n `FAILURE`."
     },
     "queueTtl": {
-      "properties": {
-        "seconds": {
-          "type": "integer",
-          "description": "Signed seconds of the span of time. Must be from -315,576,000,000\n to +315,576,000,000 inclusive. Note: these bounds are computed from:\n 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years"
-        },
-        "nanos": {
-          "type": "integer",
-          "description": "Signed fractions of a second at nanosecond resolution of the span\n of time. Durations less than one second are represented with a 0\n `seconds` field and a positive or negative `nanos` field. For durations\n of one second or more, a non-zero value for the `nanos` field must be\n of the same sign as the `seconds` field. Must be from -999,999,999\n to +999,999,999 inclusive."
-        }
-      },
       "additionalProperties": true,
-      "type": "object",
+      "type": "string",
       "description": "TTL in queue for this build. If provided and the build is enqueued longer\n than this value, the build will expire and the build status will be\n `EXPIRED`.\n\n The TTL starts ticking from create_time."
     },
     "artifacts": {
@@ -381,7 +353,9 @@
                     },
                     "value": {
                       "type": "string",
-                      "description": "The hash value."
+                      "description": "The hash value.",
+                      "format": "binary",
+                      "binaryEncoding": "base64"
                     }
                   },
                   "additionalProperties": true,
@@ -575,7 +549,9 @@
           },
           "secretEnv": {
             "additionalProperties": {
-              "type": "string"
+              "type": "string",
+              "format": "binary",
+              "binaryEncoding": "base64"
             },
             "type": "object",
             "description": "Map of environment variable name to its encrypted value.\n\n Secret environment variables must be unique across all of a build's\n secrets, and must be used by at least one build step. Values can be at most\n 64 KB in size. There can be at most 100 secret values across all of a\n build's secrets."

--- a/jsonschema/google/events/cloud/firestore/v1/DocumentEventData.json
+++ b/jsonschema/google/events/cloud/firestore/v1/DocumentEventData.json
@@ -115,7 +115,9 @@
         },
         "bytesValue": {
           "type": "string",
-          "description": "A bytes value.\n\n Must not exceed 1 MiB - 89 bytes.\n Only the first 1,500 bytes are considered by queries."
+          "description": "A bytes value.\n\n Must not exceed 1 MiB - 89 bytes.\n Only the first 1,500 bytes are considered by queries.",
+          "format": "binary",
+          "binaryEncoding": "base64"
         },
         "referenceValue": {
           "type": "string",

--- a/jsonschema/google/events/cloud/pubsub/v1/MessagePublishedData.json
+++ b/jsonschema/google/events/cloud/pubsub/v1/MessagePublishedData.json
@@ -17,7 +17,9 @@
       "properties": {
         "data": {
           "type": "string",
-          "description": "The binary data in the message."
+          "description": "The binary data in the message.",
+          "format": "binary",
+          "binaryEncoding": "base64"
         },
         "attributes": {
           "additionalProperties": {

--- a/jsonschema/google/events/cloud/scheduler/v1/SchedulerJobData.json
+++ b/jsonschema/google/events/cloud/scheduler/v1/SchedulerJobData.json
@@ -14,7 +14,9 @@
   "properties": {
     "customData": {
       "type": "string",
-      "description": "The custom data the user specified when creating the scheduler source."
+      "description": "The custom data the user specified when creating the scheduler source.",
+      "format": "binary",
+      "binaryEncoding": "base64"
     }
   },
   "additionalProperties": true,

--- a/jsonschema/google/events/firebase/auth/v1/AuthEventData.json
+++ b/jsonschema/google/events/firebase/auth/v1/AuthEventData.json
@@ -93,8 +93,23 @@
       "properties": {
         "fields": {
           "additionalProperties": {
-            "additionalProperties": true,
-            "type": "object"
+            "oneOf": [
+              {
+                "type": "array"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "object"
+              },
+              {
+                "type": "string"
+              }
+            ]
           },
           "type": "object",
           "description": "Unordered map of dynamically typed values."

--- a/jsonschema/google/events/firebase/database/v1/ReferenceEventData.json
+++ b/jsonschema/google/events/firebase/database/v1/ReferenceEventData.json
@@ -16,14 +16,42 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {
     "data": {
-      "additionalProperties": true,
-      "type": "object",
-      "description": "The original data for the reference."
+      "oneOf": [
+        {
+          "type": "array"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "object"
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "delta": {
-      "additionalProperties": true,
-      "type": "object",
-      "description": "The change in the reference data."
+      "oneOf": [
+        {
+          "type": "array"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "object"
+        },
+        {
+          "type": "string"
+        }
+      ]
     }
   },
   "additionalProperties": true,

--- a/tools/proto2jsonschema/gen.sh
+++ b/tools/proto2jsonschema/gen.sh
@@ -54,7 +54,7 @@ curl -sSL \
 unzip -q protobuf.zip
 cd ..
 
-PROTOC_PLUGIN_VERSION=0.9.7
+PROTOC_PLUGIN_VERSION=1.0.0
 echo "- Setting up protoc plugin: chrusty/protoc-gen-jsonschema@$PROTOC_PLUGIN_VERSION"
 # Pin chrusty tool to specific version: https://github.com/chrusty/protoc-gen-jsonschema/tags
 GO111MODULE=on go get -v github.com/chrusty/protoc-gen-jsonschema/cmd/protoc-gen-jsonschema@$PROTOC_PLUGIN_VERSION


### PR DESCRIPTION
Fixes https://github.com/googleapis/google-cloudevents/issues/250

Uses `PROTOC_PLUGIN_VERSION=1.0.0`.

- Better JSON representation for `google.protobuf.Value`
- Better JSON representation for `google.protobuf.Duration`

This should result in better parsing for these well known types, and types that aren't always JSON objects (hence the oneOf).

See: https://developers.google.com/protocol-buffers/docs/reference/google.protobuf
- e.g. https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Value

Gen'd updates to language clients would follow this PR. Unfortunately the `oneOf` syntax isn't the greatest with quicktype. Although it is the most accurate for the JSON (not everything is an object), and easier to deal with downstream. Look at the protobuf docs for your own assessment.