### PR TITLE
ci: only try to create a pr if it dne

### DIFF
--- a/.github/workflows/copybara.yaml
+++ b/.github/workflows/copybara.yaml
@@ -27,10 +27,13 @@ jobs:
       env:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       run: |
-        git config --global user.email "yoshi-code-bot@google.com"
-        git config --global user.name "Yoshi Code Bot"
-        gh pr create \
-        --base master \
-        --head copybara \
-        --title "[Copybara] Update with new internal changes from Piper" \
-        --body "This is a auto-generated pull request. The PR updates the default branch with new changes from the copybara branch. Refer to PR commit history for more details."
+        # Only create a PR if DNE
+        if ! [[ `gh pr list --base main --search "[Copybara]"` ]]; then
+          git config --global user.email "yoshi-code-bot@google.com"
+          git config --global user.name "Yoshi Code Bot"
+          gh pr create \
+          --base master \
+          --head copybara \
+          --title "[Copybara] Update with new internal changes from Piper" \
+          --body "This is a auto-generated pull request. The PR updates the default branch with new changes from the copybara branch. Refer to PR commit history for more details."
+        fi


### PR DESCRIPTION
No need to create a PR if already exist.

Reduces the number of failures for: https://github.com/googleapis/google-cloudevents/actions