### PR TITLE
Fix base naming branch in copybara workflow

### DIFF
--- a/.github/workflows/copybara.yaml
+++ b/.github/workflows/copybara.yaml
@@ -32,7 +32,7 @@ jobs:
           git config --global user.email "yoshi-code-bot@google.com"
           git config --global user.name "Yoshi Code Bot"
           gh pr create \
-          --base master \
+          --base main \
           --head copybara \
           --title "[Copybara] Update with new internal changes from Piper" \
           --body "This is a auto-generated pull request. The PR updates the default branch with new changes from the copybara branch. Refer to PR commit history for more details." \


### PR DESCRIPTION
Fix base naming branch (from `master` to `main`) in the copybara workflow (creating a copybara PR).