### PR TITLE
Exclude copybara branch from the Generate workflow

### DIFF
--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -13,9 +13,15 @@
 # limitations under the License.
 
 name: Generate
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+    - copybara
+  pull_request:
 jobs:
   build:
+    # Skip when it is a pull request from copybara as there might be changes in the proto schemas
+    if: github.head_ref != 'copybara'
     runs-on: ubuntu-18.04
     steps:
     - name: Check out repo


### PR DESCRIPTION
The `generate` workflow runs for any `push` or any `pull request` action and makes sure no changes have been introduced to the proto schemas.
The problem is that `copybara` branch might in fact be performing changes to those schemas (eg: adding a new one), thus making it fail, and not allowing admins to merge it without disabling branch protection first.

I'm proposing to skip this workflow for the `copybara` branch to reduce manual intervention.
FYI, once a `copybara` PR is submitted to `main`, the generator will run anyway and create a PR with any new changes.