### PR TITLE
Fetch CloudEvent type only for matching payload types

### DIFF
--- a/tools/proto2jsonschema/postgen.js
+++ b/tools/proto2jsonschema/postgen.js
@@ -21,12 +21,12 @@ const protobufjs = require('protobufjs');
 const flatten = require('flat');
 
 /**
-* This tool polishes the JSON schemas with a few modifications:
-* - Adds "$id" – "." delimited ID – e.g. "google.events.cloud.audit.v1.LogEntryData"
-* - Adds "name" – The name for the JSON schema – e.g. "LogEntryData"
-* - Adds "examples" - A list of paths to the test event data associated with the schema
-*   - e.g. ["https://googleapis.github.io/google-cloudevents/testdata/google/events/cloud/audit/v1/LogEntryData-pubsubCreateTopic.json"]
-*/
+ * This tool polishes the JSON schemas with a few modifications:
+ * - Adds "$id" – "." delimited ID – e.g. "google.events.cloud.audit.v1.LogEntryData"
+ * - Adds "name" – The name for the JSON schema – e.g. "LogEntryData"
+ * - Adds "examples" - A list of paths to the test event data associated with the schema
+ *   - e.g. ["https://googleapis.github.io/google-cloudevents/testdata/google/events/cloud/audit/v1/LogEntryData-pubsubCreateTopic.json"]
+ */
 const ROOT = path.resolve(`${__dirname}/../../jsonschema`);
 const TESTDATA = path.resolve(`${__dirname}/../../testdata`);
 console.log(`Fixing paths in dir: ${ROOT}`);
@@ -56,23 +56,23 @@ console.log(`Fixing paths in dir: ${ROOT}`);
     };
 
     /**
-    * Simplify $ref tags. This string is used for the name of fields.
-    *
-    * This couldn't be done in the previous step, because the $ref was simply wrong in that step.
-    * Now the $refs are correct (but long).
-    *
-    * We need to change the $ref name and definition.
-    *
-    * We do so by:
-    * - Looking at the JSON schema "definitions".
-    * - Create a map from the longhand to shortand value
-    * - replaceAll longhand to shorthand values
-    * @example "google.events.cloud.firestore.v1.Value" -> "Value"
-    * @example "google.events.cloud.cloudbuild.v1.StorageSource" -> StorageSource
-    *
-    * In terms of scale, within the original 10 CloudEvents, there are 6 fields
-    * that contain long-hand tags that are fixed with this modification.
-    */
+     * Simplify $ref tags. This string is used for the name of fields.
+     *
+     * This couldn't be done in the previous step, because the $ref was simply wrong in that step.
+     * Now the $refs are correct (but long).
+     *
+     * We need to change the $ref name and definition.
+     *
+     * We do so by:
+     * - Looking at the JSON schema "definitions".
+     * - Create a map from the longhand to shortand value
+     * - replaceAll longhand to shorthand values
+     * @example "google.events.cloud.firestore.v1.Value" -> "Value"
+     * @example "google.events.cloud.cloudbuild.v1.StorageSource" -> StorageSource
+     *
+     * In terms of scale, within the original 10 CloudEvents, there are 6 fields
+     * that contain long-hand tags that are fixed with this modification.
+     */
     const getAllRefs = (schema) => {
       if (!schema.definitions) return [];
       return Object.keys(schema.definitions);
@@ -80,11 +80,11 @@ console.log(`Fixing paths in dir: ${ROOT}`);
     const allRefs = getAllRefs(resultJSON);
 
     /**
-    * Map of replacement definitions.
-    * @example 'google.api.MonitoredResource' -> 'MonitoredResource'
-    * @example 'google.events.cloud.firestore.v1.Value' -> 'Value'
-    * @example 'google.rpc.Status': 'Status'
-    */
+     * Map of replacement definitions.
+     * @example 'google.api.MonitoredResource' -> 'MonitoredResource'
+     * @example 'google.events.cloud.firestore.v1.Value' -> 'Value'
+     * @example 'google.rpc.Status': 'Status'
+     */
     const replacementMap = {};
     allRefs.map(ref => {
       const shorthandFromDotNotation = ref.split('.').reverse()[0];
@@ -92,14 +92,14 @@ console.log(`Fixing paths in dir: ${ROOT}`);
     });
 
     /**
-    * Clean the schema output:
-    * - Replace definitions "#/definitions/{key}" with "#/definitions/{value}"
-    *
-    * @example
-    * - FROM: "$ref": "google.events.cloud.cloudbuild.v1.Volume"
-    * - TO: "$ref": "#/definitions/Volume"
-    * @param {Object} obj the JSON object.
-    //  */
+     * Clean the schema output:
+     * - Replace definitions "#/definitions/{key}" with "#/definitions/{value}"
+     *
+     * @example
+     * - FROM: "$ref": "google.events.cloud.cloudbuild.v1.Volume"
+     * - TO: "$ref": "#/definitions/Volume"
+     * @param {Object} obj the JSON object.
+     //  */
     const cleanSchema = (obj) => {
       for (const key in obj) {
         // Base cases

--- a/tools/proto2jsonschema/postgen.js
+++ b/tools/proto2jsonschema/postgen.js
@@ -99,7 +99,7 @@ console.log(`Fixing paths in dir: ${ROOT}`);
      * - FROM: "$ref": "google.events.cloud.cloudbuild.v1.Volume"
      * - TO: "$ref": "#/definitions/Volume"
      * @param {Object} obj the JSON object.
-     //  */
+    //  */
     const cleanSchema = (obj) => {
       for (const key in obj) {
         // Base cases
@@ -129,9 +129,9 @@ console.log(`Fixing paths in dir: ${ROOT}`);
     cleanSchema(resultJSON);
 
     /**
-    * Clean up schema output:
-    * - Replace keys with values in replacementMap
-    */
+     * Clean up schema output:
+     * - Replace keys with values in replacementMap
+     */
     for (const [k, v] of Object.entries(resultJSON.definitions || {})) {
       delete resultJSON.definitions[k];
       resultJSON.definitions[replacementMap[k]] = v;
@@ -147,24 +147,24 @@ console.log(`Fixing paths in dir: ${ROOT}`);
 })();
 
 /**
-* Gets the "$id" for the JSON schema.
-* @param {string} filepath The input file path
-* @example filepath: /Documents/github/googleapis/google-cloudevents/jsonschema/google/events/cloud/pubsub/v1/MessagePublishedData.json
-* @example out: https://googleapis.github.io/google-cloudevents/jsonschema/google/events/cloud/pubsub/v1/MessagePublishedData.json
-* @returns {string} A URI that represents the ID of the file.
-*/
+ * Gets the "$id" for the JSON schema.
+ * @param {string} filepath The input file path
+ * @example filepath: /Documents/github/googleapis/google-cloudevents/jsonschema/google/events/cloud/pubsub/v1/MessagePublishedData.json
+ * @example out: https://googleapis.github.io/google-cloudevents/jsonschema/google/events/cloud/pubsub/v1/MessagePublishedData.json
+ * @returns {string} A URI that represents the ID of the file.
+ */
 function getId(filepath) {
   const subpath = filepath.split('jsonschema/')[1];
   return `https://googleapis.github.io/google-cloudevents/jsonschema/${subpath}`;
 }
 
 /**
-* Gets the cloudevent package represented in the JSON schema.
-* @param {string} filepath The input file path
-* @example filepath: /Documents/github/googleapis/google-cloudevents/jsonschema/google/events/cloud/audit/v1/LogEntryData.json
-* @returns {string} The CloudEvent package for this file represents.
-* @example out: google.events.cloud.audit.v1
-*/
+ * Gets the cloudevent package represented in the JSON schema.
+ * @param {string} filepath The input file path
+ * @example filepath: /Documents/github/googleapis/google-cloudevents/jsonschema/google/events/cloud/audit/v1/LogEntryData.json
+ * @returns {string} The CloudEvent package for this file represents.
+ * @example out: google.events.cloud.audit.v1
+ */
 function getCloudEventPackage(filepath) {
   const removePrefix = filepath.split('jsonschema/')[1];
   const removeSuffix = removePrefix.substring(0, removePrefix.lastIndexOf("/"));
@@ -172,12 +172,12 @@ function getCloudEventPackage(filepath) {
 }
 
 /**
-* Gets the paths to test event data associated with the schema.
-* @param {string} filepath The input file path
-* @example filepath: /Documents/github/googleapis/google-cloudevents/jsonschema/google/events/cloud/audit/v1/LogEntryData.json
-* @example out: ["https://googleapis.github.io/google-cloudevents/testdata/google/events/cloud/audit/v1/LogEntryData-pubsubCreateTopic.json"]
-* @returns {array[string]} An array of paths to the test event data.
-*/
+ * Gets the paths to test event data associated with the schema.
+ * @param {string} filepath The input file path
+ * @example filepath: /Documents/github/googleapis/google-cloudevents/jsonschema/google/events/cloud/audit/v1/LogEntryData.json
+ * @example out: ["https://googleapis.github.io/google-cloudevents/testdata/google/events/cloud/audit/v1/LogEntryData-pubsubCreateTopic.json"]
+ * @returns {array[string]} An array of paths to the test event data.
+ */
 function getExamples(filepath) {
   const removePrefix = filepath.split('jsonschema/')[1];
   const removeSuffix = removePrefix.substring(0, removePrefix.lastIndexOf("/"));
@@ -198,13 +198,13 @@ function getExamples(filepath) {
 }
 
 /**
-* Gets the CloudEvent properties from the corresponding `events.proto` file.
-* @param {string} packageName The package name of the CloudEvent.
-* @param {string} dataName The CloudEvent payload type name.
-* @return {object} cloudevent The CloudEvent properties object.
-* @return {string[]} cloudevent.types The CloudEvent type strings.
-* @return {string} cloudevent.product The CloudEvent product.
-*/
+ * Gets the CloudEvent properties from the corresponding `events.proto` file.
+ * @param {string} packageName The package name of the CloudEvent.
+ * @param {string} dataName The CloudEvent payload type name.
+ * @return {object} cloudevent The CloudEvent properties object.
+ * @return {string[]} cloudevent.types The CloudEvent type strings.
+ * @return {string} cloudevent.product The CloudEvent product.
+ */
 function getCloudEventProperties(packageName, dataName) {
   const packageNameSplit = packageName.split('.');
   const protoPath = packageNameSplit.join('/');

--- a/tools/proto2jsonschema/postgen.js
+++ b/tools/proto2jsonschema/postgen.js
@@ -14,242 +14,242 @@
  * limitations under the License.
  */
 
- const path = require('path');
- const fs = require('fs');
- const recursive = require("recursive-readdir");
- const protobufjs = require('protobufjs');
- const flatten = require('flat');
+const path = require('path');
+const fs = require('fs');
+const recursive = require("recursive-readdir");
+const protobufjs = require('protobufjs');
+const flatten = require('flat');
 
- /**
-  * This tool polishes the JSON schemas with a few modifications:
-  * - Adds "$id" – "." delimited ID – e.g. "google.events.cloud.audit.v1.LogEntryData"
-  * - Adds "name" – The name for the JSON schema – e.g. "LogEntryData"
-  * - Adds "examples" - A list of paths to the test event data associated with the schema
-  *   - e.g. ["https://googleapis.github.io/google-cloudevents/testdata/google/events/cloud/audit/v1/LogEntryData-pubsubCreateTopic.json"]
-  */
- const ROOT = path.resolve(`${__dirname}/../../jsonschema`);
- const TESTDATA = path.resolve(`${__dirname}/../../testdata`);
- console.log(`Fixing paths in dir: ${ROOT}`);
- (async () => {
-   const filePaths = await recursive(ROOT);
-   // For every file
-   filePaths.map(filePath => {
-     const dataName = path.basename(filePath,  path.extname(filePath)); // i.e. LogEntryData
+/**
+* This tool polishes the JSON schemas with a few modifications:
+* - Adds "$id" – "." delimited ID – e.g. "google.events.cloud.audit.v1.LogEntryData"
+* - Adds "name" – The name for the JSON schema – e.g. "LogEntryData"
+* - Adds "examples" - A list of paths to the test event data associated with the schema
+*   - e.g. ["https://googleapis.github.io/google-cloudevents/testdata/google/events/cloud/audit/v1/LogEntryData-pubsubCreateTopic.json"]
+*/
+const ROOT = path.resolve(`${__dirname}/../../jsonschema`);
+const TESTDATA = path.resolve(`${__dirname}/../../testdata`);
+console.log(`Fixing paths in dir: ${ROOT}`);
+(async () => {
+  const filePaths = await recursive(ROOT);
+  // For every file
+  filePaths.map(filePath => {
+    const dataName = path.basename(filePath,  path.extname(filePath)); // i.e. LogEntryData
 
-     // Create the modified JSON schema output
-     const json = JSON.parse(fs.readFileSync(filePath).toString());
+    // Create the modified JSON schema output
+    const json = JSON.parse(fs.readFileSync(filePath).toString());
 
-     // Replace backslashes with forward-slashes to allow the script
-     // to work on Windows.
-     filePath = filePath.replace(/\\/g, '/');
+    // Replace backslashes with forward-slashes to allow the script
+    // to work on Windows.
+    filePath = filePath.replace(/\\/g, '/');
 
-     const packageName = getCloudEventPackage(filePath);
-     const resultJSON = {
-       // Add the $id and name first
-       $id: getId(filePath),
-       name: dataName,
-       examples: getExamples(filePath),
-       package: packageName,
-       datatype: `${packageName}.${dataName}`,
-       ...getCloudEventProperties(packageName, dataName),
-       ...json
-     };
+    const packageName = getCloudEventPackage(filePath);
+    const resultJSON = {
+      // Add the $id and name first
+      $id: getId(filePath),
+      name: dataName,
+      examples: getExamples(filePath),
+      package: packageName,
+      datatype: `${packageName}.${dataName}`,
+      ...getCloudEventProperties(packageName, dataName),
+      ...json
+    };
 
-     /**
-      * Simplify $ref tags. This string is used for the name of fields.
-      *
-      * This couldn't be done in the previous step, because the $ref was simply wrong in that step.
-      * Now the $refs are correct (but long).
-      *
-      * We need to change the $ref name and definition.
-      *
-      * We do so by:
-      * - Looking at the JSON schema "definitions".
-      * - Create a map from the longhand to shortand value
-      * - replaceAll longhand to shorthand values
-      * @example "google.events.cloud.firestore.v1.Value" -> "Value"
-      * @example "google.events.cloud.cloudbuild.v1.StorageSource" -> StorageSource
-      *
-      * In terms of scale, within the original 10 CloudEvents, there are 6 fields
-      * that contain long-hand tags that are fixed with this modification.
-      */
-     const getAllRefs = (schema) => {
-       if (!schema.definitions) return [];
-       return Object.keys(schema.definitions);
-     };
-     const allRefs = getAllRefs(resultJSON);
+    /**
+    * Simplify $ref tags. This string is used for the name of fields.
+    *
+    * This couldn't be done in the previous step, because the $ref was simply wrong in that step.
+    * Now the $refs are correct (but long).
+    *
+    * We need to change the $ref name and definition.
+    *
+    * We do so by:
+    * - Looking at the JSON schema "definitions".
+    * - Create a map from the longhand to shortand value
+    * - replaceAll longhand to shorthand values
+    * @example "google.events.cloud.firestore.v1.Value" -> "Value"
+    * @example "google.events.cloud.cloudbuild.v1.StorageSource" -> StorageSource
+    *
+    * In terms of scale, within the original 10 CloudEvents, there are 6 fields
+    * that contain long-hand tags that are fixed with this modification.
+    */
+    const getAllRefs = (schema) => {
+      if (!schema.definitions) return [];
+      return Object.keys(schema.definitions);
+    };
+    const allRefs = getAllRefs(resultJSON);
 
-     /**
-      * Map of replacement definitions.
-      * @example 'google.api.MonitoredResource' -> 'MonitoredResource'
-      * @example 'google.events.cloud.firestore.v1.Value' -> 'Value'
-      * @example 'google.rpc.Status': 'Status'
-      */
-     const replacementMap = {};
-     allRefs.map(ref => {
-       const shorthandFromDotNotation = ref.split('.').reverse()[0];
-       replacementMap[ref] = shorthandFromDotNotation;
-     });
+    /**
+    * Map of replacement definitions.
+    * @example 'google.api.MonitoredResource' -> 'MonitoredResource'
+    * @example 'google.events.cloud.firestore.v1.Value' -> 'Value'
+    * @example 'google.rpc.Status': 'Status'
+    */
+    const replacementMap = {};
+    allRefs.map(ref => {
+      const shorthandFromDotNotation = ref.split('.').reverse()[0];
+      replacementMap[ref] = shorthandFromDotNotation;
+    });
 
-     /**
-      * Clean the schema output:
-      * - Replace definitions "#/definitions/{key}" with "#/definitions/{value}"
-      *
-      * @example
-      * - FROM: "$ref": "google.events.cloud.cloudbuild.v1.Volume"
-      * - TO: "$ref": "#/definitions/Volume"
-      * @param {Object} obj the JSON object.
-     //  */
-     const cleanSchema = (obj) => {
-       for (const key in obj) {
-         // Base cases
-         const isRef = (key === '$ref');
-         if (isRef) {
-           const uri = obj[key];
-           for (const [find, replace] of Object.entries(replacementMap)) {
-             if (uri === `#/definitions/${find}`) {
-               obj[key] = `#/definitions/${replace}`;
-             }
-           }
-         }
+    /**
+    * Clean the schema output:
+    * - Replace definitions "#/definitions/{key}" with "#/definitions/{value}"
+    *
+    * @example
+    * - FROM: "$ref": "google.events.cloud.cloudbuild.v1.Volume"
+    * - TO: "$ref": "#/definitions/Volume"
+    * @param {Object} obj the JSON object.
+    //  */
+    const cleanSchema = (obj) => {
+      for (const key in obj) {
+        // Base cases
+        const isRef = (key === '$ref');
+        if (isRef) {
+          const uri = obj[key];
+          for (const [find, replace] of Object.entries(replacementMap)) {
+            if (uri === `#/definitions/${find}`) {
+              obj[key] = `#/definitions/${replace}`;
+            }
+          }
+        }
 
-         // Recursive case
-         if (typeof obj[key] === 'object') {
-           cleanSchema(obj[key]);
+        // Recursive case
+        if (typeof obj[key] === 'object') {
+          cleanSchema(obj[key]);
 
-           // Change key name
-           // if key in replacementMap
-           if (replacementMap[obj[key]]) {
-             // then change key name
-             obj[key] = replacementMap[obj[key]];
-           }
-         }
-       }
-     };
-     cleanSchema(resultJSON);
+          // Change key name
+          // if key in replacementMap
+          if (replacementMap[obj[key]]) {
+            // then change key name
+            obj[key] = replacementMap[obj[key]];
+          }
+        }
+      }
+    };
+    cleanSchema(resultJSON);
 
-     /**
-      * Clean up schema output:
-      * - Replace keys with values in replacementMap
-      */
-     for (const [k, v] of Object.entries(resultJSON.definitions || {})) {
-       delete resultJSON.definitions[k];
-       resultJSON.definitions[replacementMap[k]] = v;
-     }
+    /**
+    * Clean up schema output:
+    * - Replace keys with values in replacementMap
+    */
+    for (const [k, v] of Object.entries(resultJSON.definitions || {})) {
+      delete resultJSON.definitions[k];
+      resultJSON.definitions[replacementMap[k]] = v;
+    }
 
-     // Format JSON
-     let jsonString = JSON.stringify(resultJSON, null, 2);
+    // Format JSON
+    let jsonString = JSON.stringify(resultJSON, null, 2);
 
-     // Write back JSON Schema
-     fs.writeFileSync(filePath, jsonString);
-   });
-   console.log(`Fixed ${filePaths.length} schemas!`);
- })();
+    // Write back JSON Schema
+    fs.writeFileSync(filePath, jsonString);
+  });
+  console.log(`Fixed ${filePaths.length} schemas!`);
+})();
 
- /**
-  * Gets the "$id" for the JSON schema.
-  * @param {string} filepath The input file path
-  * @example filepath: /Documents/github/googleapis/google-cloudevents/jsonschema/google/events/cloud/pubsub/v1/MessagePublishedData.json
-  * @example out: https://googleapis.github.io/google-cloudevents/jsonschema/google/events/cloud/pubsub/v1/MessagePublishedData.json
-  * @returns {string} A URI that represents the ID of the file.
-  */
- function getId(filepath) {
-   const subpath = filepath.split('jsonschema/')[1];
-   return `https://googleapis.github.io/google-cloudevents/jsonschema/${subpath}`;
- }
+/**
+* Gets the "$id" for the JSON schema.
+* @param {string} filepath The input file path
+* @example filepath: /Documents/github/googleapis/google-cloudevents/jsonschema/google/events/cloud/pubsub/v1/MessagePublishedData.json
+* @example out: https://googleapis.github.io/google-cloudevents/jsonschema/google/events/cloud/pubsub/v1/MessagePublishedData.json
+* @returns {string} A URI that represents the ID of the file.
+*/
+function getId(filepath) {
+  const subpath = filepath.split('jsonschema/')[1];
+  return `https://googleapis.github.io/google-cloudevents/jsonschema/${subpath}`;
+}
 
- /**
-  * Gets the cloudevent package represented in the JSON schema.
-  * @param {string} filepath The input file path
-  * @example filepath: /Documents/github/googleapis/google-cloudevents/jsonschema/google/events/cloud/audit/v1/LogEntryData.json
-  * @returns {string} The CloudEvent package for this file represents.
-  * @example out: google.events.cloud.audit.v1
-  */
- function getCloudEventPackage(filepath) {
-   const removePrefix = filepath.split('jsonschema/')[1];
-   const removeSuffix = removePrefix.substring(0, removePrefix.lastIndexOf("/"));
-   return removeSuffix.replace(/\//g, '.');
- }
+/**
+* Gets the cloudevent package represented in the JSON schema.
+* @param {string} filepath The input file path
+* @example filepath: /Documents/github/googleapis/google-cloudevents/jsonschema/google/events/cloud/audit/v1/LogEntryData.json
+* @returns {string} The CloudEvent package for this file represents.
+* @example out: google.events.cloud.audit.v1
+*/
+function getCloudEventPackage(filepath) {
+  const removePrefix = filepath.split('jsonschema/')[1];
+  const removeSuffix = removePrefix.substring(0, removePrefix.lastIndexOf("/"));
+  return removeSuffix.replace(/\//g, '.');
+}
 
- /**
-  * Gets the paths to test event data associated with the schema.
-  * @param {string} filepath The input file path
-  * @example filepath: /Documents/github/googleapis/google-cloudevents/jsonschema/google/events/cloud/audit/v1/LogEntryData.json
-  * @example out: ["https://googleapis.github.io/google-cloudevents/testdata/google/events/cloud/audit/v1/LogEntryData-pubsubCreateTopic.json"]
-  * @returns {array[string]} An array of paths to the test event data.
-  */
- function getExamples(filepath) {
-   const removePrefix = filepath.split('jsonschema/')[1];
-   const removeSuffix = removePrefix.substring(0, removePrefix.lastIndexOf("/"));
-   const testDataPath = TESTDATA + '/' + removeSuffix;
-   var filesAndDirs;
-   try {
-     filesAndDirs = fs.readdirSync(testDataPath, { withFileTypes: true });
-   } catch (err) {
-     return [];
-   }
+/**
+* Gets the paths to test event data associated with the schema.
+* @param {string} filepath The input file path
+* @example filepath: /Documents/github/googleapis/google-cloudevents/jsonschema/google/events/cloud/audit/v1/LogEntryData.json
+* @example out: ["https://googleapis.github.io/google-cloudevents/testdata/google/events/cloud/audit/v1/LogEntryData-pubsubCreateTopic.json"]
+* @returns {array[string]} An array of paths to the test event data.
+*/
+function getExamples(filepath) {
+  const removePrefix = filepath.split('jsonschema/')[1];
+  const removeSuffix = removePrefix.substring(0, removePrefix.lastIndexOf("/"));
+  const testDataPath = TESTDATA + '/' + removeSuffix;
+  var filesAndDirs;
+  try {
+    filesAndDirs = fs.readdirSync(testDataPath, { withFileTypes: true });
+  } catch (err) {
+    return [];
+  }
 
-   return filesAndDirs
-     .map((value) => {
-       const isJSONFile = value.isFile() && value.name.endsWith('.json');
-       return isJSONFile ? `https://googleapis.github.io/google-cloudevents/testdata/${removeSuffix}/${value.name}` : null;
-     })
-     .filter((value) => value != null);
- }
+  return filesAndDirs
+    .map((value) => {
+      const isJSONFile = value.isFile() && value.name.endsWith('.json');
+      return isJSONFile ? `https://googleapis.github.io/google-cloudevents/testdata/${removeSuffix}/${value.name}` : null;
+    })
+    .filter((value) => value != null);
+}
 
- /**
-  * Gets the CloudEvent properties from the corresponding `events.proto` file.
-  * @param {string} packageName The package name of the CloudEvent.
-  * @param {string} dataName The CloudEvent payload type name.
-  * @return {object} cloudevent The CloudEvent properties object.
-  * @return {string[]} cloudevent.types The CloudEvent type strings.
-  * @return {string} cloudevent.product The CloudEvent product.
-  */
- function getCloudEventProperties(packageName, dataName) {
-   const packageNameSplit = packageName.split('.');
-   const protoPath = packageNameSplit.join('/');
-   const eventPath = path.resolve(`${__dirname}/../../proto/${protoPath}/events.proto`);
-   const proto = protobufjs.loadSync(eventPath);
-   const protoAsJSON = proto.toJSON();
+/**
+* Gets the CloudEvent properties from the corresponding `events.proto` file.
+* @param {string} packageName The package name of the CloudEvent.
+* @param {string} dataName The CloudEvent payload type name.
+* @return {object} cloudevent The CloudEvent properties object.
+* @return {string[]} cloudevent.types The CloudEvent type strings.
+* @return {string} cloudevent.product The CloudEvent product.
+*/
+function getCloudEventProperties(packageName, dataName) {
+  const packageNameSplit = packageName.split('.');
+  const protoPath = packageNameSplit.join('/');
+  const eventPath = path.resolve(`${__dirname}/../../proto/${protoPath}/events.proto`);
+  const proto = protobufjs.loadSync(eventPath);
+  const protoAsJSON = proto.toJSON();
 
-   const CLOUD_EVENT_TYPE = '(google.events.cloud_event_type)';
-   const CLOUD_EVENT_PRODUCT = '(google.events.cloud_event_product)';
+  const CLOUD_EVENT_TYPE = '(google.events.cloud_event_type)';
+  const CLOUD_EVENT_PRODUCT = '(google.events.cloud_event_product)';
 
-   // We'll traverse the proto file to extract CloudEvent properties.
-   // The file contents are nested in the proto package.
-   let eventMessages = protoAsJSON;
-   for (const k of packageNameSplit) {
-     eventMessages = eventMessages["nested"][k];
-   }
+  // We'll traverse the proto file to extract CloudEvent properties.
+  // The file contents are nested in the proto package.
+  let eventMessages = protoAsJSON;
+  for (const k of packageNameSplit) {
+    eventMessages = eventMessages["nested"][k];
+  }
 
-   // Find the product if specified.
-   let product = '';
-   if (eventMessages.hasOwnProperty("options") && eventMessages["options"].hasOwnProperty(CLOUD_EVENT_PRODUCT)) {
-     product = eventMessages["options"][CLOUD_EVENT_PRODUCT];
-   }
+  // Find the product if specified.
+  let product = '';
+  if (eventMessages.hasOwnProperty("options") && eventMessages["options"].hasOwnProperty(CLOUD_EVENT_PRODUCT)) {
+    product = eventMessages["options"][CLOUD_EVENT_PRODUCT];
+  }
 
-   // Find all CloudEvent types associated with this payload.
-   const cloudeventTypes = [];
-   eventMessages = eventMessages["nested"];
-   for (const e in eventMessages) {
-     const event = eventMessages[e];
-     if (!event.hasOwnProperty("options")) continue;
-     const eventOptions = event["options"];
-     if (!eventOptions.hasOwnProperty(CLOUD_EVENT_TYPE)) continue;
-     if (!event.hasOwnProperty("fields")) continue;
-     const eventFields = event["fields"];
-     if (!eventFields.hasOwnProperty("data")) continue;
-     const eventData = eventFields["data"];
-     if (!eventData.hasOwnProperty("type")) continue;
-     const eventDataType = eventData["type"];
-     if (eventDataType == dataName) {
-       cloudeventTypes.push(eventOptions[CLOUD_EVENT_TYPE]);
-     }
-   }
+  // Find all CloudEvent types associated with this payload.
+  const cloudeventTypes = [];
+  eventMessages = eventMessages["nested"];
+  for (const e in eventMessages) {
+    const event = eventMessages[e];
+    if (!event.hasOwnProperty("options")) continue;
+    const eventOptions = event["options"];
+    if (!eventOptions.hasOwnProperty(CLOUD_EVENT_TYPE)) continue;
+    if (!event.hasOwnProperty("fields")) continue;
+    const eventFields = event["fields"];
+    if (!eventFields.hasOwnProperty("data")) continue;
+    const eventData = eventFields["data"];
+    if (!eventData.hasOwnProperty("type")) continue;
+    const eventDataType = eventData["type"];
+    if (eventDataType == dataName) {
+      cloudeventTypes.push(eventOptions[CLOUD_EVENT_TYPE]);
+    }
+  }
 
-   // Return types and product.
-   return {
-     cloudeventTypes,
-     product,
-   };
- }
+  // Return types and product.
+  return {
+    cloudeventTypes,
+    product,
+  };
+}

--- a/tools/proto2jsonschema/postgen.js
+++ b/tools/proto2jsonschema/postgen.js
@@ -14,223 +14,242 @@
  * limitations under the License.
  */
 
-const path = require('path');
-const fs = require('fs');
-const recursive = require("recursive-readdir");
-const protobufjs = require('protobufjs');
-const flatten = require('flat');
+ const path = require('path');
+ const fs = require('fs');
+ const recursive = require("recursive-readdir");
+ const protobufjs = require('protobufjs');
+ const flatten = require('flat');
 
-/**
- * This tool polishes the JSON schemas with a few modifications:
- * - Adds "$id" – "." delimited ID – e.g. "google.events.cloud.audit.v1.LogEntryData"
- * - Adds "name" – The name for the JSON schema – e.g. "LogEntryData"
- * - Adds "examples" - A list of paths to the test event data associated with the schema
- *   - e.g. ["https://googleapis.github.io/google-cloudevents/testdata/google/events/cloud/audit/v1/LogEntryData-pubsubCreateTopic.json"]
- */
-const ROOT = path.resolve(`${__dirname}/../../jsonschema`);
-const TESTDATA = path.resolve(`${__dirname}/../../testdata`);
-console.log(`Fixing paths in dir: ${ROOT}`);
-(async () => {
-  const filePaths = await recursive(ROOT);
-  // For every file
-  filePaths.map(filePath => {
-    const dataName = path.basename(filePath,  path.extname(filePath)); // i.e. LogEntryData
-    
-    // Create the modified JSON schema output
-    const json = JSON.parse(fs.readFileSync(filePath).toString());
+ /**
+  * This tool polishes the JSON schemas with a few modifications:
+  * - Adds "$id" – "." delimited ID – e.g. "google.events.cloud.audit.v1.LogEntryData"
+  * - Adds "name" – The name for the JSON schema – e.g. "LogEntryData"
+  * - Adds "examples" - A list of paths to the test event data associated with the schema
+  *   - e.g. ["https://googleapis.github.io/google-cloudevents/testdata/google/events/cloud/audit/v1/LogEntryData-pubsubCreateTopic.json"]
+  */
+ const ROOT = path.resolve(`${__dirname}/../../jsonschema`);
+ const TESTDATA = path.resolve(`${__dirname}/../../testdata`);
+ console.log(`Fixing paths in dir: ${ROOT}`);
+ (async () => {
+   const filePaths = await recursive(ROOT);
+   // For every file
+   filePaths.map(filePath => {
+     const dataName = path.basename(filePath,  path.extname(filePath)); // i.e. LogEntryData
 
-    // Replace backslashes with forward-slashes to allow the script
-    // to work on Windows.
-    filePath = filePath.replace(/\\/g, '/');
+     // Create the modified JSON schema output
+     const json = JSON.parse(fs.readFileSync(filePath).toString());
 
-    const packageName = getCloudEventPackage(filePath);
-    const resultJSON = {
-      // Add the $id and name first
-      $id: getId(filePath),
-      name: dataName,
-      examples: getExamples(filePath),
-      package: packageName,
-      datatype: `${packageName}.${dataName}`,
-      ...getCloudEventProperties(packageName),
-      ...json
-    };
+     // Replace backslashes with forward-slashes to allow the script
+     // to work on Windows.
+     filePath = filePath.replace(/\\/g, '/');
 
-    /**
-     * Simplify $ref tags. This string is used for the name of fields.
-     *
-     * This couldn't be done in the previous step, because the $ref was simply wrong in that step.
-     * Now the $refs are correct (but long).
-     *
-     * We need to change the $ref name and definition.
-     *
-     * We do so by:
-     * - Looking at the JSON schema "definitions".
-     * - Create a map from the longhand to shortand value
-     * - replaceAll longhand to shorthand values
-     * @example "google.events.cloud.firestore.v1.Value" -> "Value"
-     * @example "google.events.cloud.cloudbuild.v1.StorageSource" -> StorageSource
-     *
-     * In terms of scale, within the original 10 CloudEvents, there are 6 fields
-     * that contain long-hand tags that are fixed with this modification.
-     */
-    const getAllRefs = (schema) => {
-      if (!schema.definitions) return [];
-      return Object.keys(schema.definitions);
-    };
-    const allRefs = getAllRefs(resultJSON);
+     const packageName = getCloudEventPackage(filePath);
+     const resultJSON = {
+       // Add the $id and name first
+       $id: getId(filePath),
+       name: dataName,
+       examples: getExamples(filePath),
+       package: packageName,
+       datatype: `${packageName}.${dataName}`,
+       ...getCloudEventProperties(packageName, dataName),
+       ...json
+     };
 
-    /**
-     * Map of replacement definitions.
-     * @example 'google.api.MonitoredResource' -> 'MonitoredResource'
-     * @example 'google.events.cloud.firestore.v1.Value' -> 'Value'
-     * @example 'google.rpc.Status': 'Status'
-     */
-    const replacementMap = {};
-    allRefs.map(ref => {
-      const shorthandFromDotNotation = ref.split('.').reverse()[0];
-      replacementMap[ref] = shorthandFromDotNotation;
-    });
+     /**
+      * Simplify $ref tags. This string is used for the name of fields.
+      *
+      * This couldn't be done in the previous step, because the $ref was simply wrong in that step.
+      * Now the $refs are correct (but long).
+      *
+      * We need to change the $ref name and definition.
+      *
+      * We do so by:
+      * - Looking at the JSON schema "definitions".
+      * - Create a map from the longhand to shortand value
+      * - replaceAll longhand to shorthand values
+      * @example "google.events.cloud.firestore.v1.Value" -> "Value"
+      * @example "google.events.cloud.cloudbuild.v1.StorageSource" -> StorageSource
+      *
+      * In terms of scale, within the original 10 CloudEvents, there are 6 fields
+      * that contain long-hand tags that are fixed with this modification.
+      */
+     const getAllRefs = (schema) => {
+       if (!schema.definitions) return [];
+       return Object.keys(schema.definitions);
+     };
+     const allRefs = getAllRefs(resultJSON);
 
-    /**
-     * Clean the schema output:
-     * - Replace definitions "#/definitions/{key}" with "#/definitions/{value}"
-     * 
-     * @example
-     * - FROM: "$ref": "google.events.cloud.cloudbuild.v1.Volume"
-     * - TO: "$ref": "#/definitions/Volume"
-     * @param {Object} obj the JSON object.
-    //  */
-    const cleanSchema = (obj) => {
-      for (const key in obj) {
-        // Base cases
-        const isRef = (key === '$ref');
-        if (isRef) {
-          const uri = obj[key];
-          for (const [find, replace] of Object.entries(replacementMap)) {
-            if (uri === `#/definitions/${find}`) {
-              obj[key] = `#/definitions/${replace}`;
-            }
-          }
-        }
-        
-        // Recursive case
-        if (typeof obj[key] === 'object') {
-          cleanSchema(obj[key]);
-          
-          // Change key name
-          // if key in replacementMap
-          if (replacementMap[obj[key]]) {
-            // then change key name
-            obj[key] = replacementMap[obj[key]];
-          }
-        }
-      }
-    };
-    cleanSchema(resultJSON);
+     /**
+      * Map of replacement definitions.
+      * @example 'google.api.MonitoredResource' -> 'MonitoredResource'
+      * @example 'google.events.cloud.firestore.v1.Value' -> 'Value'
+      * @example 'google.rpc.Status': 'Status'
+      */
+     const replacementMap = {};
+     allRefs.map(ref => {
+       const shorthandFromDotNotation = ref.split('.').reverse()[0];
+       replacementMap[ref] = shorthandFromDotNotation;
+     });
 
-    /**
-     * Clean up schema output:
-     * - Replace keys with values in replacementMap
-     */
-    for (const [k, v] of Object.entries(resultJSON.definitions || {})) {
-      delete resultJSON.definitions[k];
-      resultJSON.definitions[replacementMap[k]] = v;
-    }
+     /**
+      * Clean the schema output:
+      * - Replace definitions "#/definitions/{key}" with "#/definitions/{value}"
+      *
+      * @example
+      * - FROM: "$ref": "google.events.cloud.cloudbuild.v1.Volume"
+      * - TO: "$ref": "#/definitions/Volume"
+      * @param {Object} obj the JSON object.
+     //  */
+     const cleanSchema = (obj) => {
+       for (const key in obj) {
+         // Base cases
+         const isRef = (key === '$ref');
+         if (isRef) {
+           const uri = obj[key];
+           for (const [find, replace] of Object.entries(replacementMap)) {
+             if (uri === `#/definitions/${find}`) {
+               obj[key] = `#/definitions/${replace}`;
+             }
+           }
+         }
 
-    // Format JSON
-    let jsonString = JSON.stringify(resultJSON, null, 2);
+         // Recursive case
+         if (typeof obj[key] === 'object') {
+           cleanSchema(obj[key]);
 
-    // Write back JSON Schema
-    fs.writeFileSync(filePath, jsonString);
-  });
-  console.log(`Fixed ${filePaths.length} schemas!`);
-})();
+           // Change key name
+           // if key in replacementMap
+           if (replacementMap[obj[key]]) {
+             // then change key name
+             obj[key] = replacementMap[obj[key]];
+           }
+         }
+       }
+     };
+     cleanSchema(resultJSON);
 
-/**
- * Gets the "$id" for the JSON schema.
- * @param {string} filepath The input file path
- * @example filepath: /Documents/github/googleapis/google-cloudevents/jsonschema/google/events/cloud/pubsub/v1/MessagePublishedData.json
- * @example out: https://googleapis.github.io/google-cloudevents/jsonschema/google/events/cloud/pubsub/v1/MessagePublishedData.json
- * @returns {string} A URI that represents the ID of the file.
- */
-function getId(filepath) {
-  const subpath = filepath.split('jsonschema/')[1];
-  return `https://googleapis.github.io/google-cloudevents/jsonschema/${subpath}`;
-}
+     /**
+      * Clean up schema output:
+      * - Replace keys with values in replacementMap
+      */
+     for (const [k, v] of Object.entries(resultJSON.definitions || {})) {
+       delete resultJSON.definitions[k];
+       resultJSON.definitions[replacementMap[k]] = v;
+     }
 
-/**
- * Gets the cloudevent package represented in the JSON schema.
- * @param {string} filepath The input file path
- * @example filepath: /Documents/github/googleapis/google-cloudevents/jsonschema/google/events/cloud/audit/v1/LogEntryData.json
- * @returns {string} The CloudEvent package for this file represents.
- * @example out: google.events.cloud.audit.v1
- */
-function getCloudEventPackage(filepath) {
-  const removePrefix = filepath.split('jsonschema/')[1];
-  const removeSuffix = removePrefix.substring(0, removePrefix.lastIndexOf("/"));
-  return removeSuffix.replace(/\//g, '.');
-}
+     // Format JSON
+     let jsonString = JSON.stringify(resultJSON, null, 2);
 
-/**
- * Gets the paths to test event data associated with the schema.
- * @param {string} filepath The input file path
- * @example filepath: /Documents/github/googleapis/google-cloudevents/jsonschema/google/events/cloud/audit/v1/LogEntryData.json
- * @example out: ["https://googleapis.github.io/google-cloudevents/testdata/google/events/cloud/audit/v1/LogEntryData-pubsubCreateTopic.json"]
- * @returns {array[string]} An array of paths to the test event data.
- */
-function getExamples(filepath) {
-  const removePrefix = filepath.split('jsonschema/')[1];
-  const removeSuffix = removePrefix.substring(0, removePrefix.lastIndexOf("/"));
-  const testDataPath = TESTDATA + '/' + removeSuffix;
-  var filesAndDirs;
-  try {
-    filesAndDirs = fs.readdirSync(testDataPath, { withFileTypes: true });
-  } catch (err) {
-    return [];
-  }
+     // Write back JSON Schema
+     fs.writeFileSync(filePath, jsonString);
+   });
+   console.log(`Fixed ${filePaths.length} schemas!`);
+ })();
 
-  return filesAndDirs
-    .map((value) => {
-      const isJSONFile = value.isFile() && value.name.endsWith('.json');
-      return isJSONFile ? `https://googleapis.github.io/google-cloudevents/testdata/${removeSuffix}/${value.name}` : null;
-    })
-    .filter((value) => value != null);
-}
+ /**
+  * Gets the "$id" for the JSON schema.
+  * @param {string} filepath The input file path
+  * @example filepath: /Documents/github/googleapis/google-cloudevents/jsonschema/google/events/cloud/pubsub/v1/MessagePublishedData.json
+  * @example out: https://googleapis.github.io/google-cloudevents/jsonschema/google/events/cloud/pubsub/v1/MessagePublishedData.json
+  * @returns {string} A URI that represents the ID of the file.
+  */
+ function getId(filepath) {
+   const subpath = filepath.split('jsonschema/')[1];
+   return `https://googleapis.github.io/google-cloudevents/jsonschema/${subpath}`;
+ }
 
-/**
- * Gets the CloudEvent properties from the corresponding `events.proto` file.
- * @param {string} packageName The package name of the CloudEvent.
- * @return {object} cloudevent The CloudEvent properties object.
- * @return {string[]} cloudevent.types The CloudEvent type strings.
- * @return {string} cloudevent.product The CloudEvent product.
- */
-function getCloudEventProperties(packageName) {
-  const protoPath = packageName.split('.').join('/');
-  const eventPath = path.resolve(`${__dirname}/../../proto/${protoPath}/events.proto`);
-  const proto = protobufjs.loadSync(eventPath);
-  const protoAsJSON = proto.toJSON();
+ /**
+  * Gets the cloudevent package represented in the JSON schema.
+  * @param {string} filepath The input file path
+  * @example filepath: /Documents/github/googleapis/google-cloudevents/jsonschema/google/events/cloud/audit/v1/LogEntryData.json
+  * @returns {string} The CloudEvent package for this file represents.
+  * @example out: google.events.cloud.audit.v1
+  */
+ function getCloudEventPackage(filepath) {
+   const removePrefix = filepath.split('jsonschema/')[1];
+   const removeSuffix = removePrefix.substring(0, removePrefix.lastIndexOf("/"));
+   return removeSuffix.replace(/\//g, '.');
+ }
 
-  // Flatten the protobuf representation and look directly for these keys:
-  const CLOUD_EVENT_TYPE = '(google.events.cloud_event_type)';
-  const CLOUD_EVENT_PRODUCT = '(google.events.cloud_event_product)';
-  const flattenedProtoValueMap = flatten(protoAsJSON);
-  const flattenedProtoValueMapEntries = Object.entries(flattenedProtoValueMap);
-  
-  // Go through all the keys, add the type or product if found.
-  const cloudeventTypes = [];
-  let product = '';
-  for (const [k, v] of flattenedProtoValueMapEntries) {
-    if (k.endsWith(CLOUD_EVENT_TYPE)) {
-      cloudeventTypes.push(v);
-    }
-    if (k.endsWith(CLOUD_EVENT_PRODUCT)) {
-      product = v;
-    }
-  }
+ /**
+  * Gets the paths to test event data associated with the schema.
+  * @param {string} filepath The input file path
+  * @example filepath: /Documents/github/googleapis/google-cloudevents/jsonschema/google/events/cloud/audit/v1/LogEntryData.json
+  * @example out: ["https://googleapis.github.io/google-cloudevents/testdata/google/events/cloud/audit/v1/LogEntryData-pubsubCreateTopic.json"]
+  * @returns {array[string]} An array of paths to the test event data.
+  */
+ function getExamples(filepath) {
+   const removePrefix = filepath.split('jsonschema/')[1];
+   const removeSuffix = removePrefix.substring(0, removePrefix.lastIndexOf("/"));
+   const testDataPath = TESTDATA + '/' + removeSuffix;
+   var filesAndDirs;
+   try {
+     filesAndDirs = fs.readdirSync(testDataPath, { withFileTypes: true });
+   } catch (err) {
+     return [];
+   }
 
-  // Return types and product.
-  return {
-    cloudeventTypes,
-    product,
-  };
-}
+   return filesAndDirs
+     .map((value) => {
+       const isJSONFile = value.isFile() && value.name.endsWith('.json');
+       return isJSONFile ? `https://googleapis.github.io/google-cloudevents/testdata/${removeSuffix}/${value.name}` : null;
+     })
+     .filter((value) => value != null);
+ }
+
+ /**
+  * Gets the CloudEvent properties from the corresponding `events.proto` file.
+  * @param {string} packageName The package name of the CloudEvent.
+  * @param {string} dataName The CloudEvent payload type name.
+  * @return {object} cloudevent The CloudEvent properties object.
+  * @return {string[]} cloudevent.types The CloudEvent type strings.
+  * @return {string} cloudevent.product The CloudEvent product.
+  */
+ function getCloudEventProperties(packageName, dataName) {
+   const packageNameSplit = packageName.split('.');
+   const protoPath = packageNameSplit.join('/');
+   const eventPath = path.resolve(`${__dirname}/../../proto/${protoPath}/events.proto`);
+   const proto = protobufjs.loadSync(eventPath);
+   const protoAsJSON = proto.toJSON();
+
+   const CLOUD_EVENT_TYPE = '(google.events.cloud_event_type)';
+   const CLOUD_EVENT_PRODUCT = '(google.events.cloud_event_product)';
+
+   // We'll traverse the proto file to extract CloudEvent properties.
+   // The file contents are nested in the proto package.
+   let eventMessages = protoAsJSON;
+   for (const k of packageNameSplit) {
+     eventMessages = eventMessages["nested"][k];
+   }
+
+   // Find the product if specified.
+   let product = '';
+   if (eventMessages.hasOwnProperty("options") && eventMessages["options"].hasOwnProperty(CLOUD_EVENT_PRODUCT)) {
+     product = eventMessages["options"][CLOUD_EVENT_PRODUCT];
+   }
+
+   // Find all CloudEvent types associated with this payload.
+   const cloudeventTypes = [];
+   eventMessages = eventMessages["nested"];
+   for (const e in eventMessages) {
+     const event = eventMessages[e];
+     if (!event.hasOwnProperty("options")) continue;
+     const eventOptions = event["options"];
+     if (!eventOptions.hasOwnProperty(CLOUD_EVENT_TYPE)) continue;
+     if (!event.hasOwnProperty("fields")) continue;
+     const eventFields = event["fields"];
+     if (!eventFields.hasOwnProperty("data")) continue;
+     const eventData = eventFields["data"];
+     if (!eventData.hasOwnProperty("type")) continue;
+     const eventDataType = eventData["type"];
+     if (eventDataType == dataName) {
+       cloudeventTypes.push(eventOptions[CLOUD_EVENT_TYPE]);
+     }
+   }
+
+   // Return types and product.
+   return {
+     cloudeventTypes,
+     product,
+   };
+ }


### PR DESCRIPTION
If we don't do this, then all JSON schemas get associated with every event type defined in events.proto. But those events might not all have the same payload.

For example before this change, with the following events defined in the same events.proto file:
```proto
message FooEvent {
  option (google.events.cloud_event_type) = "google.example.foo.v1.blah";
  FooEventData data = 1;
}

message BarEvent {
  option (google.events.cloud_event_type) = "google.example.bar.v1.blah";
  BarEventData data = 1;
}
```

The schemas would look like:
```json
{
  "name": "FooEventData",
  "cloudeventTypes": [
    "google.example.bar.v1.blah",
    "google.example.foo.v1.blah"
  ]
}
```
```json
{
  "name": "BarEventData",
  "cloudeventTypes": [
    "google.example.bar.v1.blah",
    "google.example.foo.v1.blah"
  ]
}
```

This change makes sure that the event types listed in the JSON schema are correct. After this change, the schemas would look like:
```json
{
  "name": "FooEventData",
  "cloudeventTypes": [
    "google.example.foo.v1.blah"
  ]
}
```
```json
{
  "name": "BarEventData",
  "cloudeventTypes": [
    "google.example.bar.v1.blah",
  ]
}
```