### PR TITLE
docs: Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ such as generated JSON schema should not be regarded as stable.
 
 ## CloudEvents in this repository
 
-This repository contains definitions for the following CloudEvents:
+This repository contains definitions for the following CloudEvent data payloads:
 
 <!-- GENERATED START -->
 |Product|Schemas|Types|


### PR DESCRIPTION
clarify that these types are not full CloudEvents, but describe the contents of the data payload. Fixes #396