### PR TITLE
refactor: Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,5 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-*     @googleapis/cloudevents-admins
+*           @googleapis/torus-dpe
+proto/      @googleapis/cloudevents-admins

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,6 @@
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
 *           @googleapis/torus-dpe
+
 proto/      @googleapis/cloudevents-admins
+json/audit/ @googleapis/cloudevents-admins


### PR DESCRIPTION
With this change, I propose we scope cloudevent-admins to the Eventarc team. This will prevent others from approving copybara PRs without a review from the Eventarc team.