### PR TITLE
chore: update CODEOWNERS - eventarc-team owner of copybara directories

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,5 +6,5 @@
 
 *           @googleapis/torus-dpe
 
-proto/      @googleapis/cloudevents-admins
-json/audit/ @googleapis/cloudevents-admins
+proto/      @googleapis/eventarc-team
+json/audit/ @googleapis/eventarc-team


### PR DESCRIPTION
Fixes #427. I've created a new GitHub TeamSync group [eventarc-team](https://github.com/orgs/googleapis/teams/eventarc-team) which is linked to the Eventarc mdb group.
The proposed changes here are to only allow Eventarc team members to approve changes in the copybara directories.