### PR TITLE
chore: update node version

### DIFF
--- a/.github/workflows/check_unexpected_changes.yaml
+++ b/.github/workflows/check_unexpected_changes.yaml
@@ -27,7 +27,7 @@ jobs:
       uses: ./.github/workflows/generate_jsonschema
 
     - name: Check for schema changes
-      working-directory: jsonschema/
+      # working-directory: jsonschema/
       run: git diff --exit-code .
 
     - if: ${{ failure() }}

--- a/.github/workflows/check_unexpected_changes.yaml
+++ b/.github/workflows/check_unexpected_changes.yaml
@@ -27,7 +27,6 @@ jobs:
       uses: ./.github/workflows/generate_jsonschema
 
     - name: Check for schema changes
-      # working-directory: jsonschema/
       run: git diff --exit-code .
 
     - if: ${{ failure() }}

--- a/.github/workflows/generate_jsonschema/action.yaml
+++ b/.github/workflows/generate_jsonschema/action.yaml
@@ -19,7 +19,9 @@ runs:
   steps:
     - name: Setup Node for gen/postgen scripts
       uses: actions/setup-node@v3
-
+      with:
+        node-version: "12"
+        
     - name: Setup Go for proto2jsonschema script
       uses: actions/setup-go@v4
       with:

--- a/.github/workflows/generate_jsonschema/action.yaml
+++ b/.github/workflows/generate_jsonschema/action.yaml
@@ -19,8 +19,6 @@ runs:
   steps:
     - name: Setup Node for gen/postgen scripts
       uses: actions/setup-node@v3
-      with:
-        node-version: "12"
 
     - name: Setup Go for proto2jsonschema script
       uses: actions/setup-go@v4

--- a/.github/workflows/generate_jsonschema/action.yaml
+++ b/.github/workflows/generate_jsonschema/action.yaml
@@ -19,9 +19,7 @@ runs:
   steps:
     - name: Setup Node for gen/postgen scripts
       uses: actions/setup-node@v3
-      with:
-        node-version: "12"
-        
+
     - name: Setup Go for proto2jsonschema script
       uses: actions/setup-go@v4
       with:

--- a/.github/workflows/test_jsonschemas.yaml
+++ b/.github/workflows/test_jsonschemas.yaml
@@ -30,8 +30,6 @@ jobs:
 
     - name: Setup Node
       uses: actions/setup-node@v3
-      with:
-        node-version: '12'
 
     - name: Validate JSON Schema
       run: ./scripts/validate_jsonschema.sh


### PR DESCRIPTION
The JSON schema generation is causing a new package-lock.json to be generated. Upgrading the node version hopefully will stop that from happening. The "fix" of only checking for changes in the jsonschema/ directory should not be needed anymore.