### PR TITLE
chore(deps): Update go version for go client smoke test

### DIFF
--- a/.github/workflows/test_clients.yaml
+++ b/.github/workflows/test_clients.yaml
@@ -105,7 +105,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.19.x
+        go-version: '^1.23.9'
 
     - name: Set Environment
       # Validation Test execution requires absolute path to testdata.


### PR DESCRIPTION
The Go version in place was go 1.19. This change updates to use the latest patch release of go 1.23. This seems like it may address the build errors such as "google.golang.org/protobuf/internal/flags: cannot compile Go 1.22 code"

I would like to separate investigating the failing .NET and Java tests.

The unexpected changes check is failing because the protos have been updated, but the JSON Schema has not yet been updated. I am holding off on updating that until we see the tests passing based on the current state of the protos.

I would like to have a code review and required checks rules bypass merge to make this change despite the other failing tests.