### PR TITLE
chore(deps): Update .NET version for .NET client smoke test #

### DIFF
--- a/.github/workflows/test_clients.yaml
+++ b/.github/workflows/test_clients.yaml
@@ -38,10 +38,10 @@ jobs:
         repository: googleapis/google-cloudevents-dotnet
         path: google-cloudevents-dotnet
 
-    - name: Setup .NET 6
+    - name: Setup .NET 8
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
 
     - name: Run smoke tests
       run: google-cloudevents-dotnet/validate-schema.sh .


### PR DESCRIPTION
This is a .NET equivalent of a problem similar to #632. Depending on the order in which broken checks are resolved, this may also require an admin merge to bypass required checks.

According to the logs for a failing smoke test at https://github.com/googleapis/google-cloudevents/actions/runs/14789546588/job/41523929026,

> Install the [8.0.408] .NET SDK or update [/home/runner/work/google-cloudevents/google-cloudevents/google-cloudevents-dotnet/global.json] to match an installed SDK.

I am not familiar with .NET runtimes but trying a naive update of the number to see what happens.